### PR TITLE
fix: repair ray can not work after vLLM v0.18.0

### DIFF
--- a/pack/.post_operation/20260605_vllm_patch_dp_port/cann/Dockerfile
+++ b/pack/.post_operation/20260605_vllm_patch_dp_port/cann/Dockerfile
@@ -1,0 +1,44 @@
+ARG CMAKE_MAX_JOBS
+ARG CANN_VERSION=8.5
+ARG CANN_ARCHS=910b
+ARG VLLM_VERSION=0.18.0
+
+FROM gpustack/runner:cann${CANN_VERSION}-${CANN_ARCHS}-vllm${VLLM_VERSION} AS vllm
+SHELL ["/bin/bash", "-eo", "pipefail", "-c"]
+
+ARG TARGETPLATFORM
+ARG TARGETOS
+ARG TARGETARCH
+
+## Patch
+#
+# Fix the wrong_dp_ray patch shipped in this released image:
+#   _next_port = port   ->   _next_port = port + 1
+# so get_open_port() advances and never hands out duplicate ports
+# (the cause of Ray "address already in use" in distributed serving).
+#
+# Idempotent & self-verifying: skip if already fixed, fail loudly if the
+# expected assignment is absent (so we never produce a silently-unfixed image).
+
+RUN <<EOF
+    # Patch
+
+    F="$(pip show vllm | grep Location: | cut -d" " -f 2)/vllm/utils/network_utils.py"
+    echo "Target: ${F}"
+    grep -n "_next_port" "${F}" || true
+    if grep -qE '^[[:space:]]*_next_port = port \+ 1[[:space:]]*$' "${F}"; then
+        echo "Already fixed (_next_port = port + 1), skipping."
+    elif grep -qE '^[[:space:]]*_next_port = port[[:space:]]*$' "${F}"; then
+        sed -i -E 's/^([[:space:]]*)_next_port = port[[:space:]]*$/\1_next_port = port + 1/' "${F}"
+        echo "Patched: _next_port = port -> _next_port = port + 1"
+    else
+        echo "ERROR: expected '_next_port = port' assignment not found in ${F}" >&2
+        exit 1
+    fi
+    grep -n "_next_port" "${F}"
+EOF
+
+## Entrypoint
+
+WORKDIR /
+ENTRYPOINT [ "tini", "--" ]

--- a/pack/.post_operation/20260605_vllm_patch_dp_port/cuda/Dockerfile
+++ b/pack/.post_operation/20260605_vllm_patch_dp_port/cuda/Dockerfile
@@ -1,0 +1,54 @@
+ARG CMAKE_MAX_JOBS
+ARG CUDA_VERSION=13.0
+ARG VLLM_VERSION=0.21.0
+
+FROM gpustack/runner:cuda${CUDA_VERSION}-vllm${VLLM_VERSION} AS vllm
+SHELL ["/bin/bash", "-eo", "pipefail", "-c"]
+
+ARG TARGETPLATFORM
+ARG TARGETOS
+ARG TARGETARCH
+
+## Patch
+#
+# Fix the wrong_dp_ray patch shipped in this released image:
+#   _next_port = port   ->   _next_port = port + 1
+# so get_open_port() advances and never hands out duplicate ports
+# (the cause of Ray "address already in use" in distributed serving).
+#
+# Idempotent & self-verifying: skip if already fixed, fail loudly if the
+# expected assignment is absent (so we never produce a silently-unfixed image).
+
+RUN <<EOF
+    # Patch
+
+    F="$(pip show vllm | grep Location: | cut -d" " -f 2)/vllm/utils/network_utils.py"
+    echo "Target: ${F}"
+    grep -n "_next_port" "${F}" || true
+    if grep -qE '^[[:space:]]*_next_port = port \+ 1[[:space:]]*$' "${F}"; then
+        echo "Already fixed (_next_port = port + 1), skipping."
+    elif grep -qE '^[[:space:]]*_next_port = port[[:space:]]*$' "${F}"; then
+        sed -i -E 's/^([[:space:]]*)_next_port = port[[:space:]]*$/\1_next_port = port + 1/' "${F}"
+        echo "Patched: _next_port = port -> _next_port = port + 1"
+    else
+        echo "ERROR: expected '_next_port = port' assignment not found in ${F}" >&2
+        exit 1
+    fi
+    grep -n "_next_port" "${F}"
+EOF
+
+## Pin Ray
+# Downgrade Ray to 2.54.0: ray 2.55 (ray-project/ray#61029) breaks distributed
+# ray.init when the driver has no co-located raylet (gpustack runs vllm and
+# ray-head in separate containers). vLLM only needs ray>=2.x.
+
+RUN <<EOF
+    # Pin Ray
+    pip install --no-cache-dir ray==2.54.0
+    pip show ray | grep -i '^Version:' || true
+EOF
+
+## Entrypoint
+
+WORKDIR /
+ENTRYPOINT [ "tini", "--" ]

--- a/pack/.post_operation/20260605_vllm_patch_dp_port/matrix.yaml
+++ b/pack/.post_operation/20260605_vllm_patch_dp_port/matrix.yaml
@@ -1,0 +1,135 @@
+rules:
+
+  #
+  # NVIDIA CUDA
+  #
+  # Re-tag already-released vLLM images to fix the wrong_dp_ray patch
+  # (_next_port = port  ->  _next_port = port + 1).
+  #
+
+  ## CUDA 13.0 - vLLM 0.21.0
+  - backend: "cuda"
+    services:
+      - "vllm"
+    args:
+      - "CUDA_VERSION=13.0"
+      - "VLLM_VERSION=0.21.0"
+  ## CUDA 13.0 - vLLM 0.20.2
+  - backend: "cuda"
+    services:
+      - "vllm"
+    args:
+      - "CUDA_VERSION=13.0"
+      - "VLLM_VERSION=0.20.2"
+  ## CUDA 13.0 - vLLM 0.19.1
+  - backend: "cuda"
+    services:
+      - "vllm"
+    args:
+      - "CUDA_VERSION=13.0"
+      - "VLLM_VERSION=0.19.1"
+  ## CUDA 13.0 - vLLM 0.18.1
+  - backend: "cuda"
+    services:
+      - "vllm"
+    args:
+      - "CUDA_VERSION=13.0"
+      - "VLLM_VERSION=0.18.1"
+  ## CUDA 12.9 - vLLM 0.21.0
+  - backend: "cuda"
+    services:
+      - "vllm"
+    args:
+      - "CUDA_VERSION=12.9"
+      - "VLLM_VERSION=0.21.0"
+  ## CUDA 12.9 - vLLM 0.20.2
+  - backend: "cuda"
+    services:
+      - "vllm"
+    args:
+      - "CUDA_VERSION=12.9"
+      - "VLLM_VERSION=0.20.2"
+  ## CUDA 12.9 - vLLM 0.19.1
+  - backend: "cuda"
+    services:
+      - "vllm"
+    args:
+      - "CUDA_VERSION=12.9"
+      - "VLLM_VERSION=0.19.1"
+  ## CUDA 12.9 - vLLM 0.18.1
+  - backend: "cuda"
+    services:
+      - "vllm"
+    args:
+      - "CUDA_VERSION=12.9"
+      - "VLLM_VERSION=0.18.1"
+
+  #
+  # AMD ROCm
+  #
+
+  ## ROCm 7.2 - vLLM 0.21.0
+  - backend: "rocm"
+    services:
+      - "vllm"
+    platforms:
+      - "linux/amd64"
+    args:
+      - "ROCM_VERSION=7.2"
+      - "VLLM_VERSION=0.21.0"
+  ## ROCm 7.2 - vLLM 0.20.2
+  - backend: "rocm"
+    services:
+      - "vllm"
+    platforms:
+      - "linux/amd64"
+    args:
+      - "ROCM_VERSION=7.2"
+      - "VLLM_VERSION=0.20.2"
+  ## ROCm 7.2 - vLLM 0.19.1
+  - backend: "rocm"
+    services:
+      - "vllm"
+    platforms:
+      - "linux/amd64"
+    args:
+      - "ROCM_VERSION=7.2"
+      - "VLLM_VERSION=0.19.1"
+  ## ROCm 7.0 - vLLM 0.18.1
+  - backend: "rocm"
+    services:
+      - "vllm"
+    platforms:
+      - "linux/amd64"
+    args:
+      - "ROCM_VERSION=7.0"
+      - "VLLM_VERSION=0.18.1"
+
+  #
+  # Ascend CANN
+  #
+
+  ## CANN 8.5 (A3) - vLLM 0.18.0
+  - backend: "cann"
+    services:
+      - "vllm"
+    args:
+      - "CANN_VERSION=8.5"
+      - "CANN_ARCHS=a3"
+      - "VLLM_VERSION=0.18.0"
+  ## CANN 8.5 (910B) - vLLM 0.18.0
+  - backend: "cann"
+    services:
+      - "vllm"
+    args:
+      - "CANN_VERSION=8.5"
+      - "CANN_ARCHS=910b"
+      - "VLLM_VERSION=0.18.0"
+  ## CANN 8.5 (310P) - vLLM 0.18.0
+  - backend: "cann"
+    services:
+      - "vllm"
+    args:
+      - "CANN_VERSION=8.5"
+      - "CANN_ARCHS=310p"
+      - "VLLM_VERSION=0.18.0"

--- a/pack/.post_operation/20260605_vllm_patch_dp_port/rocm/Dockerfile
+++ b/pack/.post_operation/20260605_vllm_patch_dp_port/rocm/Dockerfile
@@ -1,0 +1,54 @@
+ARG CMAKE_MAX_JOBS
+ARG ROCM_VERSION=7.2
+ARG VLLM_VERSION=0.21.0
+
+FROM gpustack/runner:rocm${ROCM_VERSION}-vllm${VLLM_VERSION} AS vllm
+SHELL ["/bin/bash", "-eo", "pipefail", "-c"]
+
+ARG TARGETPLATFORM
+ARG TARGETOS
+ARG TARGETARCH
+
+## Patch
+#
+# Fix the wrong_dp_ray patch shipped in this released image:
+#   _next_port = port   ->   _next_port = port + 1
+# so get_open_port() advances and never hands out duplicate ports
+# (the cause of Ray "address already in use" in distributed serving).
+#
+# Idempotent & self-verifying: skip if already fixed, fail loudly if the
+# expected assignment is absent (so we never produce a silently-unfixed image).
+
+RUN <<EOF
+    # Patch
+
+    F="$(pip show vllm | grep Location: | cut -d" " -f 2)/vllm/utils/network_utils.py"
+    echo "Target: ${F}"
+    grep -n "_next_port" "${F}" || true
+    if grep -qE '^[[:space:]]*_next_port = port \+ 1[[:space:]]*$' "${F}"; then
+        echo "Already fixed (_next_port = port + 1), skipping."
+    elif grep -qE '^[[:space:]]*_next_port = port[[:space:]]*$' "${F}"; then
+        sed -i -E 's/^([[:space:]]*)_next_port = port[[:space:]]*$/\1_next_port = port + 1/' "${F}"
+        echo "Patched: _next_port = port -> _next_port = port + 1"
+    else
+        echo "ERROR: expected '_next_port = port' assignment not found in ${F}" >&2
+        exit 1
+    fi
+    grep -n "_next_port" "${F}"
+EOF
+
+## Pin Ray
+# Downgrade Ray to 2.54.0: ray 2.55 (ray-project/ray#61029) breaks distributed
+# ray.init when the driver has no co-located raylet (gpustack runs vllm and
+# ray-head in separate containers). vLLM only needs ray>=2.x.
+
+RUN <<EOF
+    # Pin Ray
+    pip install --no-cache-dir ray==2.54.0
+    pip show ray | grep -i '^Version:' || true
+EOF
+
+## Entrypoint
+
+WORKDIR /
+ENTRYPOINT [ "tini", "--" ]

--- a/pack/cann/patches/vllm/001_wrong_dp_ray.patch
+++ b/pack/cann/patches/vllm/001_wrong_dp_ray.patch
@@ -17,7 +17,7 @@ index 6b940c92d..230f96c3d 100644
 -    return _get_open_port()
 +    global _next_port
 +    port = _get_open_port(_next_port)
-+    _next_port = port
++    _next_port = port + 1
 +    return port
  
  

--- a/pack/cuda/Dockerfile.vllm
+++ b/pack/cuda/Dockerfile.vllm
@@ -200,8 +200,10 @@ ARG TARGETARCH
 RUN <<EOF
     # Ray
 
-    # Install Ray Client and Default
-    RAY_VERSION=2.55.1
+    # Install Ray Client and Default.
+    # Pinned to 2.54.0: ray 2.55 (ray-project/ray#61029) breaks distributed
+    # ray.init when the driver has no co-located raylet (gpustack split containers).
+    RAY_VERSION=2.54.0
     cat <<EOT >/tmp/requirements.txt
 ray[cgraph]==${RAY_VERSION}
 ray[client]==${RAY_VERSION}

--- a/pack/cuda/patches/vllm/001_wrong_dp_ray.patch
+++ b/pack/cuda/patches/vllm/001_wrong_dp_ray.patch
@@ -17,7 +17,7 @@ index 6b940c92d..230f96c3d 100644
 -    return _get_open_port()
 +    global _next_port
 +    port = _get_open_port(_next_port)
-+    _next_port = port
++    _next_port = port + 1
 +    return port
  
  

--- a/pack/rocm/Dockerfile.vllm
+++ b/pack/rocm/Dockerfile.vllm
@@ -319,8 +319,10 @@ ARG TARGETARCH
 RUN <<EOF
     # Ray
 
-    # Install Ray Client and Default
-    RAY_VERSION=2.55.1
+    # Install Ray Client and Default.
+    # Pinned to 2.54.0: ray 2.55 (ray-project/ray#61029) breaks distributed
+    # ray.init when the driver has no co-located raylet (gpustack split containers).
+    RAY_VERSION=2.54.0
     cat <<EOT >/tmp/requirements.txt
 ray[cgraph]==${RAY_VERSION}
 ray[client]==${RAY_VERSION}

--- a/pack/rocm/patches/vllm/001_wrong_dp_ray.patch
+++ b/pack/rocm/patches/vllm/001_wrong_dp_ray.patch
@@ -17,7 +17,7 @@ index 6b940c92d..230f96c3d 100644
 -    return _get_open_port()
 +    global _next_port
 +    port = _get_open_port(_next_port)
-+    _next_port = port
++    _next_port = port + 1
 +    return port
  
  


### PR DESCRIPTION
Repaired the "address already in use" issue reported by Ray during startup by using _next_port = port + 1. Also, pinned Ray to version 2.54.0 because the previously used version 2.55.1 is incompatible with the current GPUStack method for launching Ray workloads, which prevented successful connections.