### PR TITLE
feat(vllm): add fastokens as extra dependency

### DIFF
--- a/pack/cann/Dockerfile.vllm
+++ b/pack/cann/Dockerfile.vllm
@@ -440,6 +440,9 @@ RUN <<EOF
 librosa
 soundfile
 mistral_common[audio]
+
+# tokenizer extras
+fastokens
 EOT
     uv pip install \
         -r /tmp/requirements.txt

--- a/pack/cann/Dockerfile.vllm
+++ b/pack/cann/Dockerfile.vllm
@@ -442,7 +442,7 @@ soundfile
 mistral_common[audio]
 
 # tokenizer extras
-fastokens
+fastokens==0.2.0
 EOT
     uv pip install \
         -r /tmp/requirements.txt

--- a/pack/cuda/Dockerfile.vllm
+++ b/pack/cuda/Dockerfile.vllm
@@ -320,6 +320,9 @@ RUN <<EOF
 librosa
 soundfile
 mistral_common[audio]
+
+# tokenizer extras
+fastokens
 EOT
     uv pip install \
         -r /tmp/requirements.txt

--- a/pack/cuda/Dockerfile.vllm
+++ b/pack/cuda/Dockerfile.vllm
@@ -322,7 +322,7 @@ soundfile
 mistral_common[audio]
 
 # tokenizer extras
-fastokens
+fastokens==0.2.0
 EOT
     uv pip install \
         -r /tmp/requirements.txt

--- a/pack/rocm/Dockerfile.vllm
+++ b/pack/rocm/Dockerfile.vllm
@@ -437,6 +437,9 @@ mistral_common[audio]
 
 # petit extras
 petit-kernel
+
+# tokenizer extras
+fastokens
 EOT
     uv pip install \
         -r /tmp/requirements.txt

--- a/pack/rocm/Dockerfile.vllm
+++ b/pack/rocm/Dockerfile.vllm
@@ -439,7 +439,7 @@ mistral_common[audio]
 petit-kernel
 
 # tokenizer extras
-fastokens
+fastokens==0.2.0
 EOT
     uv pip install \
         -r /tmp/requirements.txt


### PR DESCRIPTION
vLLM has fast tokenizer https://docs.vllm.ai/en/latest/api/vllm/tokenizers/fastokens/. We can activate this tokenizer for qwen and other popular models by `VLLM_USE_FASTOKENS=1`. But we need `fastokens` (https://github.com/crusoecloud/fastokens) python package in image.

This pull request adds fastokens python package to vllm images