### PR TITLE
feat(hggc): split Dockerfile into per-service Dockerfile.vllm and Dockerfile.sglang

### DIFF
--- a/pack/hggc/Dockerfile.sglang
+++ b/pack/hggc/Dockerfile.sglang
@@ -1,0 +1,331 @@
+# Package logic:
+# 1. runtime stage:
+#    - Install tools.
+#    - Upgrade GCC if needed.
+#    - Install C buildkit.
+#    - Upgrade Python if needed.
+#    - Install Python buildkit.
+# 2. sglang stage:
+#    - Postprocess, review installation.
+
+# Argument usage:
+# - PYTHON_VERSION: Version of Python to use.
+# - CMAKE_MAX_JOBS: (PLACEHOLDER) Maximum number of jobs to use for CMake, default is empty,
+#   which means it will use the number of available CPU cores.
+# - HGGC_VERSION: Version of T-Head HGGC runtime environment to use.
+# - HGGC_VERSION_EXTRA: Extra version string for T-Head HGGC runtime environment to use.
+# - HGGC_ARCHS: (PLACEHOLDER) Arch variant list supports for this runtime environment.
+# - SGLANG_VERSION: Version of SGLang to use.
+# - SGLANG_TORCH_VERSION: (PLACEHOLDER) Version of Torch for SGLang to use.
+# - SGLANG_BASE_IMAGE: Base (vanilla) image for SGLang, which already ships the T-Head HGGC
+#   SDK, Torch and SGLang. Defaults to the per-service vanilla image.
+ARG PYTHON_VERSION=3.12
+ARG CMAKE_MAX_JOBS
+ARG HGGC_VERSION=13.0
+ARG HGGC_VERSION_EXTRA
+ARG HGGC_ARCHS
+ARG SGLANG_VERSION=0.5.12
+ARG SGLANG_TORCH_VERSION=2.10.0
+ARG SGLANG_BASE_IMAGE=gpustack/runner:hggc${HGGC_VERSION}${HGGC_VERSION_EXTRA}-sglang${SGLANG_VERSION}-python${PYTHON_VERSION}-vanilla
+
+# Stage Bake Runtime
+#
+# Example build command:
+#   docker build --progress=plain --platform=linux/amd64 --file=pack/hggc/Dockerfile.sglang --tag=gpustack/runner:hggc${HGGC_VERSION}-sglang${SGLANG_VERSION}-python${PYTHON_VERSION}-linux-amd64 --target=runtime pack/hggc
+#
+
+FROM ${SGLANG_BASE_IMAGE} AS runtime
+SHELL ["/bin/bash", "-eo", "pipefail", "-c"]
+
+ARG TARGETPLATFORM
+ARG TARGETOS
+ARG TARGETARCH
+
+## Install tools
+
+ENV DEBIAN_FRONTEND=noninteractive \
+    LANG='en_US.UTF-8' \
+    LANGUAGE='en_US:en' \
+    LC_ALL='en_US.UTF-8'
+
+RUN <<EOF
+    # Tools
+
+    sed -i 's/mirrors.cloud.aliyuncs/mirrors.aliyun/g' \
+        /etc/apt/sources.list.d/ubuntu.sources || true
+
+    # Refresh
+    apt-get update -y && apt-get install -y --no-install-recommends \
+        software-properties-common apt-transport-https \
+        ca-certificates gnupg2 lsb-release gnupg-agent \
+      && apt-get update -y \
+      && add-apt-repository -y ppa:ubuntu-toolchain-r/test \
+      && apt-get update -y
+
+    # Install
+    apt-get install -y --no-install-recommends \
+        ca-certificates build-essential binutils bash openssl \
+        curl wget aria2 \
+        git git-lfs \
+        unzip xz-utils \
+        tzdata locales \
+        iproute2 iputils-ping ifstat net-tools dnsutils pciutils ipmitool \
+        procps sysstat htop \
+        tini vim jq bc tree
+
+    # Update locale
+    localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
+
+    # Update timezone
+    rm -f /etc/localtime \
+        && ln -sf /usr/share/zoneinfo/Asia/Shanghai /etc/localtime \
+        && echo "Asia/Shanghai" > /etc/timezone \
+        && dpkg-reconfigure --frontend noninteractive tzdata
+
+    # Cleanup
+    rm -rf /var/tmp/* \
+        && rm -rf /tmp/* \
+        && rm -rf /var/cache/apt
+EOF
+
+## Upgrade GCC if needed
+
+RUN <<EOF
+    # GCC
+
+    # Upgrade GCC if the Ubuntu version is lower than 21.04.
+    source /etc/os-release
+    if (( $(echo "${VERSION_ID} > 21.04" | bc -l) )); then
+        echo "Skipping GCC upgrade for ${VERSION_ID}..."
+        exit 0
+    fi
+
+    # Install
+    apt-get install -y --no-install-recommends \
+        gcc-11 g++-11 gfortran-11 gfortran
+
+    # Update alternatives
+    if [[ -f /etc/alternatives/gcov-dump ]]; then update-alternatives --remove-all gcov-dump; fi; update-alternatives --install /usr/bin/gcov-dump gcov-dump /usr/bin/gcov-dump-11 10
+    if [[ -f /etc/alternatives/lto-dump ]]; then update-alternatives --remove-all lto-dump; fi; update-alternatives --install /usr/bin/lto-dump lto-dump /usr/bin/lto-dump-11 10
+    if [[ -f /etc/alternatives/gcov ]]; then update-alternatives --remove-all gcov; fi; update-alternatives --install /usr/bin/gcov gcov /usr/bin/gcov-11 10
+    if [[ -f /etc/alternatives/gcc ]]; then update-alternatives --remove-all gcc; fi; update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-11 10
+    if [[ -f /etc/alternatives/gcc-nm ]]; then update-alternatives --remove-all gcc-nm; fi; update-alternatives --install /usr/bin/gcc-nm gcc-nm /usr/bin/gcc-nm-11 10
+    if [[ -f /etc/alternatives/cpp ]]; then update-alternatives --remove-all cpp; fi; update-alternatives --install /usr/bin/cpp cpp /usr/bin/cpp-11 10
+    if [[ -f /etc/alternatives/g++ ]]; then update-alternatives --remove-all g++; fi; update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-11 10
+    if [[ -f /etc/alternatives/gcc-ar ]]; then update-alternatives --remove-all gcc-ar; fi; update-alternatives --install /usr/bin/gcc-ar gcc-ar /usr/bin/gcc-ar-11 10
+    if [[ -f /etc/alternatives/gcov-tool ]]; then update-alternatives --remove-all gcov-tool; fi; update-alternatives --install /usr/bin/gcov-tool gcov-tool /usr/bin/gcov-tool-11 10
+    if [[ -f /etc/alternatives/gcc-ranlib ]]; then update-alternatives --remove-all gcc-ranlib; fi; update-alternatives --install /usr/bin/gcc-ranlib gcc-ranlib /usr/bin/gcc-ranlib-11 10
+    if [[ -f /etc/alternatives/gfortran ]]; then update-alternatives --remove-all gfortran; fi; update-alternatives --install /usr/bin/gfortran gfortran /usr/bin/gfortran-11 10
+
+    # Cleanup
+    rm -rf /var/tmp/* \
+        && rm -rf /tmp/* \
+        && rm -rf /var/cache/apt
+EOF
+
+## Install C buildkit
+
+RUN <<EOF
+    # C buildkit
+
+    # Install
+    apt-get install -y --no-install-recommends \
+        make ninja-build pkg-config ccache
+    curl --retry 3 --retry-connrefused -fL "https://github.com/Kitware/CMake/releases/download/v3.31.7/cmake-3.31.7-linux-$(uname -m).tar.gz" | tar -zx -C /usr --strip-components 1
+
+    # Install dependencies
+    apt-get install -y --no-install-recommends \
+        perl-openssl-defaults perl yasm \
+        zlib1g zlib1g-dev libbz2-dev libffi-dev libgdbm-dev libgdbm-compat-dev \
+        openssl libssl-dev libsqlite3-dev lcov libomp-dev \
+        libblas-dev liblapack-dev libopenblas-dev libblas3 liblapack3 libhdf5-dev \
+        libxml2 libxslt1-dev libgmpxx4ldbl \
+        libncurses5-dev libreadline6-dev libsqlite3-dev \
+        liblzma-dev lzma lzma-dev tk-dev uuid-dev \
+        ffmpeg libjpeg-dev libpng-dev libtiff-dev libwebp-dev \
+        libnuma1 libnuma-dev libjemalloc-dev \
+        libgrpc-dev libgrpc++-dev libprotobuf-dev protobuf-compiler protobuf-compiler-grpc \
+        libnl-route-3-200 libnl-3-200 libnl-3-dev  libnl-route-3-dev \
+        libibverbs1 libibverbs-dev \
+        libibumad3 libibumad-dev \
+        libtool \
+        ibverbs-providers libibverbs-dev \
+        openmpi-bin openmpi-common libopenmpi-dev
+
+    # Cleanup
+    rm -rf /var/tmp/* \
+        && rm -rf /tmp/* \
+        && rm -rf /var/cache/apt
+EOF
+
+## Upgrade Python if needed
+
+ARG PYTHON_VERSION
+
+ENV PYTHON_VERSION=${PYTHON_VERSION}
+
+RUN <<EOF
+    # Python
+
+    if (( $(echo "$(python3 --version | cut -d' ' -f2 | cut -d'.' -f1,2) == ${PYTHON_VERSION}" | bc -l) )); then
+        echo "Skipping Python upgrade for ${PYTHON_VERSION}..."
+        # The apt operations above may pull in a system libpython${PYTHON_VERSION},
+        # which then overrides the base image's bundled libpython through the ldconfig
+        # cache. When that happens the interpreter starts resolving "dist-packages"
+        # instead of its own "site-packages" and can no longer import its bundled pip.
+        # Force the base prefix's libdir to take priority so the bundled libpython wins.
+        PYTHON_LIB_PREFIX=$(python3 -c "import sys; print(sys.base_prefix);")
+        echo "${PYTHON_LIB_PREFIX}/lib" > /etc/ld.so.conf.d/000-python3.conf
+        echo "${PYTHON_LIB_PREFIX}/lib64" >> /etc/ld.so.conf.d/000-python3.conf
+        ldconfig
+        exit 0
+    fi
+
+    # Add deadsnakes PPA for Python versions
+    for i in 1 2 3; do
+        add-apt-repository -y ppa:deadsnakes/ppa && break || { echo "Attempt $i failed, retrying in 5s..."; sleep 5; }
+    done
+    apt-get update -y
+
+    # Install
+    apt-get install -y --no-install-recommends \
+        python${PYTHON_VERSION} \
+        python${PYTHON_VERSION}-dev \
+        python${PYTHON_VERSION}-venv \
+        python${PYTHON_VERSION}-lib2to3 \
+        python${PYTHON_VERSION}-gdbm \
+        python${PYTHON_VERSION}-tk
+    if (( $(echo "${PYTHON_VERSION} <= 3.11" | bc -l) )); then
+        apt-get install -y --no-install-recommends \
+            python${PYTHON_VERSION}-distutils
+    fi
+
+    # Update alternatives
+    if [[ -f /etc/alternatives/python3 ]]; then update-alternatives --remove-all python3; fi; update-alternatives --install /usr/bin/python3 python3 /usr/bin/python${PYTHON_VERSION} 1
+    if [[ -f /etc/alternatives/python ]]; then update-alternatives --remove-all python; fi; update-alternatives --install /usr/bin/python python /usr/bin/python${PYTHON_VERSION} 1
+    curl -sS "https://bootstrap.pypa.io/get-pip.py" | python${PYTHON_VERSION}
+    if [[ -f /etc/alternatives/2to3 ]]; then update-alternatives --remove-all 2to3; fi; update-alternatives --install /usr/bin/2to3 2to3 /usr/bin/2to3${PYTHON_VERSION} 1 || true
+    if [[ -f /etc/alternatives/pydoc3 ]]; then update-alternatives --remove-all pydoc3; fi; update-alternatives --install /usr/bin/pydoc3 pydoc3 /usr/bin/pydoc${PYTHON_VERSION} 1 || true
+    if [[ -f /etc/alternatives/idle3 ]]; then update-alternatives --remove-all idle3; fi; update-alternatives --install /usr/bin/idle3 idle3 /usr/bin/idle${PYTHON_VERSION} 1 || true
+    if [[ -f /etc/alternatives/python3-config ]]; then update-alternatives --remove-all python3-config; fi; update-alternatives --install /usr/bin/python3-config python3-config /usr/bin/python${PYTHON_VERSION}-config 1 || true
+
+    # Cleanup
+    rm -rf /var/tmp/* \
+        && rm -rf /tmp/* \
+        && rm -rf /var/cache/apt
+EOF
+
+## Install Python buildkit
+
+ENV PIP_NO_CACHE_DIR=1 \
+    PIP_DISABLE_PIP_VERSION_CHECK=1 \
+    PIP_ROOT_USER_ACTION=ignore \
+    PIPX_HOME=/root/.local/share/pipx \
+    PIPX_LOCAL_VENVS=/root/.local/share/pipx/venvs \
+    UV_NO_CACHE=1 \
+    UV_HTTP_TIMEOUT=500 \
+    UV_INDEX_STRATEGY="unsafe-best-match"
+
+RUN <<EOF
+    # Buildkit
+
+    rm -rf /root/.pip/pip.conf
+    cat <<EOT >/root/.pip/pip.conf
+[global]
+index-url = https://mirrors.aliyun.com/pypi/simple/
+
+[install]
+trusted-host = mirrors.aliyun.com
+EOT
+
+    cat <<EOT >/tmp/requirements.txt
+build
+cmake<4
+ninja<1.11
+setuptools>=77.0.3,<80.0.0
+setuptools-scm
+packaging<25
+wheel==0.45.1
+pybind11<3
+Cython
+psutil
+pipx<=1.8.0
+uv<=0.9.11
+EOT
+    python3 -m pip install -r /tmp/requirements.txt
+
+    # Cleanup
+    rm -rf /var/tmp/* \
+        && rm -rf /tmp/*
+EOF
+
+## Declare Environment
+
+ARG HGGC_VERSION
+ARG HGGC_ARCHS
+
+ENV HGGC_HOME="/usr/local/PPU_SDK" \
+    HGGC_PATH="/usr/local/PPU_SDK" \
+    HGGC_VERSION=${HGGC_VERSION} \
+    HGGC_ARCHS=${HGGC_ARCHS}
+
+# Stage SGLang
+#
+# Example build command:
+#   docker build --progress=plain --platform=linux/amd64 --file=pack/hggc/Dockerfile.sglang --tag=gpustack/runner:hggc${HGGC_VERSION}-sglang${SGLANG_VERSION}-linux-amd64 --target=sglang pack/hggc
+#
+
+FROM runtime AS sglang
+SHELL ["/bin/bash", "-eo", "pipefail", "-c"]
+
+ARG TARGETPLATFORM
+ARG TARGETOS
+ARG TARGETARCH
+
+ENV UV_SYSTEM_PYTHON=1 \
+    UV_PRERELEASE=allow \
+    UV_SKIP_WHEEL_FILENAME_CHECK=1
+
+## Install Torch
+
+ARG SGLANG_TORCH_VERSION
+
+ENV SGLANG_TORCH_VERSION=${SGLANG_TORCH_VERSION}
+
+## Nothing to do, as the Torch has installed in global.
+
+## Install SGLang
+
+ARG SGLANG_VERSION
+
+ENV SGLANG_VERSION=${SGLANG_VERSION}
+
+## Nothing to do, as the SGLang has installed in global.
+
+## Postprocess
+
+RUN <<EOF
+    # Postprocess
+
+    # Review
+    uv pip tree \
+        --package sglang \
+        --package sglang-router \
+        --package sgl-kernel \
+        --package flash-attn \
+        --package triton \
+        --package vllm \
+        --package torch \
+        --package deep-ep \
+        --package deep-gemm \
+        --package ipython
+EOF
+
+## Entrypoint
+
+ENV SGLANG_ALLOW_OVERWRITE_LONGER_CONTEXT_LEN=1 \
+    SGLANG_MOE_PADDING=1 \
+    SGLANG_SET_CPU_AFFINITY=1
+
+WORKDIR /
+ENTRYPOINT [ "tini", "--" ]

--- a/pack/hggc/Dockerfile.vllm
+++ b/pack/hggc/Dockerfile.vllm
@@ -1,0 +1,324 @@
+# Package logic:
+# 1. runtime stage:
+#    - Install tools.
+#    - Upgrade GCC if needed.
+#    - Install C buildkit.
+#    - Upgrade Python if needed.
+#    - Install Python buildkit.
+# 2. vllm stage:
+#    - Postprocess, review installation.
+
+# Argument usage:
+# - PYTHON_VERSION: Version of Python to use.
+# - CMAKE_MAX_JOBS: (PLACEHOLDER) Maximum number of jobs to use for CMake, default is empty,
+#   which means it will use the number of available CPU cores.
+# - HGGC_VERSION: Version of T-Head HGGC runtime environment to use.
+# - HGGC_VERSION_EXTRA: Extra version string for T-Head HGGC runtime environment to use.
+# - HGGC_ARCHS: (PLACEHOLDER) Arch variant list supports for this runtime environment.
+# - VLLM_VERSION: Version of vLLM to use.
+# - VLLM_TORCH_VERSION: (PLACEHOLDER) Version of Torch for vLLM to use.
+# - VLLM_BASE_IMAGE: Base (vanilla) image for vLLM, which already ships the T-Head HGGC
+#   SDK, Torch and vLLM. Defaults to the per-service vanilla image.
+ARG PYTHON_VERSION=3.12
+ARG CMAKE_MAX_JOBS
+ARG HGGC_VERSION=13.0
+ARG HGGC_VERSION_EXTRA
+ARG HGGC_ARCHS
+ARG VLLM_VERSION=0.20.1
+ARG VLLM_TORCH_VERSION=2.10.0
+ARG VLLM_BASE_IMAGE=gpustack/runner:hggc${HGGC_VERSION}${HGGC_VERSION_EXTRA}-vllm${VLLM_VERSION}-python${PYTHON_VERSION}-vanilla
+
+# Stage Bake Runtime
+#
+# Example build command:
+#   docker build --progress=plain --platform=linux/amd64 --file=pack/hggc/Dockerfile.vllm --tag=gpustack/runner:hggc${HGGC_VERSION}-vllm${VLLM_VERSION}-python${PYTHON_VERSION}-linux-amd64 --target=runtime pack/hggc
+#
+
+FROM ${VLLM_BASE_IMAGE} AS runtime
+SHELL ["/bin/bash", "-eo", "pipefail", "-c"]
+
+ARG TARGETPLATFORM
+ARG TARGETOS
+ARG TARGETARCH
+
+## Install tools
+
+ENV DEBIAN_FRONTEND=noninteractive \
+    LANG='en_US.UTF-8' \
+    LANGUAGE='en_US:en' \
+    LC_ALL='en_US.UTF-8'
+
+RUN <<EOF
+    # Tools
+
+    sed -i 's/mirrors.cloud.aliyuncs/mirrors.aliyun/g' \
+        /etc/apt/sources.list.d/ubuntu.sources || true
+
+    # Refresh
+    apt-get update -y && apt-get install -y --no-install-recommends \
+        software-properties-common apt-transport-https \
+        ca-certificates gnupg2 lsb-release gnupg-agent \
+      && apt-get update -y \
+      && add-apt-repository -y ppa:ubuntu-toolchain-r/test \
+      && apt-get update -y
+
+    # Install
+    apt-get install -y --no-install-recommends \
+        ca-certificates build-essential binutils bash openssl \
+        curl wget aria2 \
+        git git-lfs \
+        unzip xz-utils \
+        tzdata locales \
+        iproute2 iputils-ping ifstat net-tools dnsutils pciutils ipmitool \
+        procps sysstat htop \
+        tini vim jq bc tree
+
+    # Update locale
+    localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
+
+    # Update timezone
+    rm -f /etc/localtime \
+        && ln -sf /usr/share/zoneinfo/Asia/Shanghai /etc/localtime \
+        && echo "Asia/Shanghai" > /etc/timezone \
+        && dpkg-reconfigure --frontend noninteractive tzdata
+
+    # Cleanup
+    rm -rf /var/tmp/* \
+        && rm -rf /tmp/* \
+        && rm -rf /var/cache/apt
+EOF
+
+## Upgrade GCC if needed
+
+RUN <<EOF
+    # GCC
+
+    # Upgrade GCC if the Ubuntu version is lower than 21.04.
+    source /etc/os-release
+    if (( $(echo "${VERSION_ID} > 21.04" | bc -l) )); then
+        echo "Skipping GCC upgrade for ${VERSION_ID}..."
+        exit 0
+    fi
+
+    # Install
+    apt-get install -y --no-install-recommends \
+        gcc-11 g++-11 gfortran-11 gfortran
+
+    # Update alternatives
+    if [[ -f /etc/alternatives/gcov-dump ]]; then update-alternatives --remove-all gcov-dump; fi; update-alternatives --install /usr/bin/gcov-dump gcov-dump /usr/bin/gcov-dump-11 10
+    if [[ -f /etc/alternatives/lto-dump ]]; then update-alternatives --remove-all lto-dump; fi; update-alternatives --install /usr/bin/lto-dump lto-dump /usr/bin/lto-dump-11 10
+    if [[ -f /etc/alternatives/gcov ]]; then update-alternatives --remove-all gcov; fi; update-alternatives --install /usr/bin/gcov gcov /usr/bin/gcov-11 10
+    if [[ -f /etc/alternatives/gcc ]]; then update-alternatives --remove-all gcc; fi; update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-11 10
+    if [[ -f /etc/alternatives/gcc-nm ]]; then update-alternatives --remove-all gcc-nm; fi; update-alternatives --install /usr/bin/gcc-nm gcc-nm /usr/bin/gcc-nm-11 10
+    if [[ -f /etc/alternatives/cpp ]]; then update-alternatives --remove-all cpp; fi; update-alternatives --install /usr/bin/cpp cpp /usr/bin/cpp-11 10
+    if [[ -f /etc/alternatives/g++ ]]; then update-alternatives --remove-all g++; fi; update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-11 10
+    if [[ -f /etc/alternatives/gcc-ar ]]; then update-alternatives --remove-all gcc-ar; fi; update-alternatives --install /usr/bin/gcc-ar gcc-ar /usr/bin/gcc-ar-11 10
+    if [[ -f /etc/alternatives/gcov-tool ]]; then update-alternatives --remove-all gcov-tool; fi; update-alternatives --install /usr/bin/gcov-tool gcov-tool /usr/bin/gcov-tool-11 10
+    if [[ -f /etc/alternatives/gcc-ranlib ]]; then update-alternatives --remove-all gcc-ranlib; fi; update-alternatives --install /usr/bin/gcc-ranlib gcc-ranlib /usr/bin/gcc-ranlib-11 10
+    if [[ -f /etc/alternatives/gfortran ]]; then update-alternatives --remove-all gfortran; fi; update-alternatives --install /usr/bin/gfortran gfortran /usr/bin/gfortran-11 10
+
+    # Cleanup
+    rm -rf /var/tmp/* \
+        && rm -rf /tmp/* \
+        && rm -rf /var/cache/apt
+EOF
+
+## Install C buildkit
+
+RUN <<EOF
+    # C buildkit
+
+    # Install
+    apt-get install -y --no-install-recommends \
+        make ninja-build pkg-config ccache
+    curl --retry 3 --retry-connrefused -fL "https://github.com/Kitware/CMake/releases/download/v3.31.7/cmake-3.31.7-linux-$(uname -m).tar.gz" | tar -zx -C /usr --strip-components 1
+
+    # Install dependencies
+    apt-get install -y --no-install-recommends \
+        perl-openssl-defaults perl yasm \
+        zlib1g zlib1g-dev libbz2-dev libffi-dev libgdbm-dev libgdbm-compat-dev \
+        openssl libssl-dev libsqlite3-dev lcov libomp-dev \
+        libblas-dev liblapack-dev libopenblas-dev libblas3 liblapack3 libhdf5-dev \
+        libxml2 libxslt1-dev libgmpxx4ldbl \
+        libncurses5-dev libreadline6-dev libsqlite3-dev \
+        liblzma-dev lzma lzma-dev tk-dev uuid-dev \
+        ffmpeg libjpeg-dev libpng-dev libtiff-dev libwebp-dev \
+        libnuma1 libnuma-dev libjemalloc-dev \
+        libgrpc-dev libgrpc++-dev libprotobuf-dev protobuf-compiler protobuf-compiler-grpc \
+        libnl-route-3-200 libnl-3-200 libnl-3-dev  libnl-route-3-dev \
+        libibverbs1 libibverbs-dev \
+        libibumad3 libibumad-dev \
+        libtool \
+        ibverbs-providers libibverbs-dev \
+        openmpi-bin openmpi-common libopenmpi-dev
+
+    # Cleanup
+    rm -rf /var/tmp/* \
+        && rm -rf /tmp/* \
+        && rm -rf /var/cache/apt
+EOF
+
+## Upgrade Python if needed
+
+ARG PYTHON_VERSION
+
+ENV PYTHON_VERSION=${PYTHON_VERSION}
+
+RUN <<EOF
+    # Python
+
+    if (( $(echo "$(python3 --version | cut -d' ' -f2 | cut -d'.' -f1,2) == ${PYTHON_VERSION}" | bc -l) )); then
+        echo "Skipping Python upgrade for ${PYTHON_VERSION}..."
+        # The apt operations above may pull in a system libpython${PYTHON_VERSION},
+        # which then overrides the base image's bundled libpython through the ldconfig
+        # cache. When that happens the interpreter starts resolving "dist-packages"
+        # instead of its own "site-packages" and can no longer import its bundled pip.
+        # Force the base prefix's libdir to take priority so the bundled libpython wins.
+        PYTHON_LIB_PREFIX=$(python3 -c "import sys; print(sys.base_prefix);")
+        echo "${PYTHON_LIB_PREFIX}/lib" > /etc/ld.so.conf.d/000-python3.conf
+        echo "${PYTHON_LIB_PREFIX}/lib64" >> /etc/ld.so.conf.d/000-python3.conf
+        ldconfig
+        exit 0
+    fi
+
+    # Add deadsnakes PPA for Python versions
+    for i in 1 2 3; do
+        add-apt-repository -y ppa:deadsnakes/ppa && break || { echo "Attempt $i failed, retrying in 5s..."; sleep 5; }
+    done
+    apt-get update -y
+
+    # Install
+    apt-get install -y --no-install-recommends \
+        python${PYTHON_VERSION} \
+        python${PYTHON_VERSION}-dev \
+        python${PYTHON_VERSION}-venv \
+        python${PYTHON_VERSION}-lib2to3 \
+        python${PYTHON_VERSION}-gdbm \
+        python${PYTHON_VERSION}-tk
+    if (( $(echo "${PYTHON_VERSION} <= 3.11" | bc -l) )); then
+        apt-get install -y --no-install-recommends \
+            python${PYTHON_VERSION}-distutils
+    fi
+
+    # Update alternatives
+    if [[ -f /etc/alternatives/python3 ]]; then update-alternatives --remove-all python3; fi; update-alternatives --install /usr/bin/python3 python3 /usr/bin/python${PYTHON_VERSION} 1
+    if [[ -f /etc/alternatives/python ]]; then update-alternatives --remove-all python; fi; update-alternatives --install /usr/bin/python python /usr/bin/python${PYTHON_VERSION} 1
+    curl -sS "https://bootstrap.pypa.io/get-pip.py" | python${PYTHON_VERSION}
+    if [[ -f /etc/alternatives/2to3 ]]; then update-alternatives --remove-all 2to3; fi; update-alternatives --install /usr/bin/2to3 2to3 /usr/bin/2to3${PYTHON_VERSION} 1 || true
+    if [[ -f /etc/alternatives/pydoc3 ]]; then update-alternatives --remove-all pydoc3; fi; update-alternatives --install /usr/bin/pydoc3 pydoc3 /usr/bin/pydoc${PYTHON_VERSION} 1 || true
+    if [[ -f /etc/alternatives/idle3 ]]; then update-alternatives --remove-all idle3; fi; update-alternatives --install /usr/bin/idle3 idle3 /usr/bin/idle${PYTHON_VERSION} 1 || true
+    if [[ -f /etc/alternatives/python3-config ]]; then update-alternatives --remove-all python3-config; fi; update-alternatives --install /usr/bin/python3-config python3-config /usr/bin/python${PYTHON_VERSION}-config 1 || true
+
+    # Cleanup
+    rm -rf /var/tmp/* \
+        && rm -rf /tmp/* \
+        && rm -rf /var/cache/apt
+EOF
+
+## Install Python buildkit
+
+ENV PIP_NO_CACHE_DIR=1 \
+    PIP_DISABLE_PIP_VERSION_CHECK=1 \
+    PIP_ROOT_USER_ACTION=ignore \
+    PIPX_HOME=/root/.local/share/pipx \
+    PIPX_LOCAL_VENVS=/root/.local/share/pipx/venvs \
+    UV_NO_CACHE=1 \
+    UV_HTTP_TIMEOUT=500 \
+    UV_INDEX_STRATEGY="unsafe-best-match"
+
+RUN <<EOF
+    # Buildkit
+
+    rm -rf /root/.pip/pip.conf
+    cat <<EOT >/root/.pip/pip.conf
+[global]
+index-url = https://mirrors.aliyun.com/pypi/simple/
+
+[install]
+trusted-host = mirrors.aliyun.com
+EOT
+
+    cat <<EOT >/tmp/requirements.txt
+build
+cmake<4
+ninja<1.11
+setuptools>=77.0.3,<80.0.0
+setuptools-scm
+packaging<25
+wheel==0.45.1
+pybind11<3
+Cython
+psutil
+pipx<=1.8.0
+uv<=0.9.11
+EOT
+    python3 -m pip install -r /tmp/requirements.txt
+
+    # Cleanup
+    rm -rf /var/tmp/* \
+        && rm -rf /tmp/*
+EOF
+
+## Declare Environment
+
+ARG HGGC_VERSION
+ARG HGGC_ARCHS
+
+ENV HGGC_HOME="/usr/local/PPU_SDK" \
+    HGGC_PATH="/usr/local/PPU_SDK" \
+    HGGC_VERSION=${HGGC_VERSION} \
+    HGGC_ARCHS=${HGGC_ARCHS}
+
+# Stage vLLM
+#
+# Example build command:
+#   docker build --progress=plain --platform=linux/amd64 --file=pack/hggc/Dockerfile.vllm --tag=gpustack/runner:hggc${HGGC_VERSION}-vllm${VLLM_VERSION}-linux-amd64 --target=vllm pack/hggc
+#
+
+FROM runtime AS vllm
+SHELL ["/bin/bash", "-eo", "pipefail", "-c"]
+
+ARG TARGETPLATFORM
+ARG TARGETOS
+ARG TARGETARCH
+
+ENV UV_SYSTEM_PYTHON=1 \
+    UV_PRERELEASE=allow \
+    UV_SKIP_WHEEL_FILENAME_CHECK=1
+
+## Install Torch
+
+ARG VLLM_TORCH_VERSION
+
+ENV VLLM_TORCH_VERSION=${VLLM_TORCH_VERSION}
+
+## Nothing to do, as the Torch has installed in global.
+
+## Install vLLM
+
+ARG VLLM_VERSION
+
+ENV VLLM_VERSION=${VLLM_VERSION}
+
+## Nothing to do, as the vLLM has installed in global.
+
+## Postprocess
+
+RUN <<EOF
+    # Postprocess
+
+    # Review
+    uv pip tree \
+        --package vllm \
+        --package flash-attn \
+        --package torch
+EOF
+
+## Entrypoint
+
+ENV RAY_EXPERIMENTAL_NOSET_CUDA_VISIBLE_DEVICES=1 \
+    MACA_SMALL_PAGESIZE_ENABLE=1 \
+    VLLM_USE_V1=0
+
+WORKDIR /
+ENTRYPOINT [ "tini", "--" ]

--- a/pack/matrix.yaml
+++ b/pack/matrix.yaml
@@ -174,7 +174,8 @@ rules:
   #
   ##
   ## Use pack flow's arguments to override the default HGGC version and version extra,
-  ## which are used in `pack/hggc/Dockerfile` to construct the image tags and build arguments.
+  ## which are used in `pack/hggc/Dockerfile.vllm` and `pack/hggc/Dockerfile.sglang`
+  ## to construct the image tags and build arguments.
   ##
   ## Get HGGC version via `VERSION=$(cat /usr/local/PPU_SDK/include/hggc.h | grep HGGC_VERSION | grep define | cut -d' ' -f3); echo "$(( ${VERSION} / 1000 )).$(( ${VERSION} % 1000 / 10 )).$(( ${VERSION} % 10 ))"`
   - backend: "hggc"
@@ -187,6 +188,7 @@ rules:
       - "HGGC_VERSION="
       - "HGGC_VERSION_EXTRA="
       - "VLLM_VERSION="
+      - "SGLANG_VERSION="
 
   #
   # MateX MACA

--- a/pack/matrix.yaml
+++ b/pack/matrix.yaml
@@ -184,11 +184,6 @@ rules:
       - "sglang"
     platforms:
       - "linux/amd64"
-    args:
-      - "HGGC_VERSION="
-      - "HGGC_VERSION_EXTRA="
-      - "VLLM_VERSION="
-      - "SGLANG_VERSION="
 
   #
   # MateX MACA


### PR DESCRIPTION
The hggc backend now ships per-service vanilla base images (hggc<ver>-vllm<ver>-...-vanilla / hggc<ver>-sglang<ver>-...-vanilla) instead of a single shared one, so the monolithic Dockerfile no longer matches the available bases. Mirror the cann/cuda/rocm layout by adding dedicated Dockerfile.vllm and Dockerfile.sglang, each self-contained: runtime stage FROM its service-specific vanilla, then the service stage FROM runtime (single --target build, no separately-built runtime image).

Also fix a pip breakage on the new vanilla base: the bundled CPython at /usr/local links libpython3.12.so, and the apt steps pull in a system libpython3.12 that overrides it via the ldconfig cache, flipping the interpreter to dist-packages and breaking `import pip`. The Python step already had the ldconfig remedy but gated it behind a check that the apt libpython defeats; make it unconditionally prioritize the base prefix libdir so the bundled libpython (and its site-packages/pip) wins.

matrix.yaml: add the SGLANG_VERSION arg placeholder for hggc, mirroring the existing VLLM_VERSION (supplied by the pack flow at dispatch).