### PR TITLE
fix: sort runner versions with PEP 440 semantics to avoid TypeError

### DIFF
--- a/gpustack_runner/runner.py
+++ b/gpustack_runner/runner.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from typing import Any
 
 from dataclasses_json import dataclass_json
+from packaging.version import InvalidVersion, Version
 
 _RE_DOCKER_IMAGE = re.compile(
     r"(?:(?P<prefix>[\w\\.\-]+(?:/[\w\\.\-]+)*)/)?runner:(?P<backend>(Host|cann|corex|cuda|dtk|hggc|maca|musa|rocm))(?P<backend_version>[XY\d\\.]+)(?:-(?P<backend_variant>\w+))?-(?P<service>(vllm|voxbox|mindie|sglang))(?P<service_version>[\w\\.]+)(?:-(?P<suffix>\w+))?",
@@ -63,6 +64,45 @@ def set_re_docker_image(pattern: str):
         missing = required_groups - _RE_DOCKER_IMAGE.groupindex.keys()
         msg = f"The provided pattern is missing required named groups: {missing}"
         raise ValueError(msg)
+
+
+def version_sort_key(
+    version: str,
+) -> tuple[int, Version | list[tuple[int, int | str]]]:
+    """
+    Build a total-order sort key for a version string.
+
+    Well-formed versions are ordered by :class:`packaging.version.Version`, which
+    follows PEP 440 semantics (e.g. ``0.5.10 > 0.5.9`` numerically, and a
+    pre-release such as ``0.5.10rc0`` sorts *before* its final release
+    ``0.5.10``). Strings that cannot be parsed as a version (e.g. ``"latest"``,
+    ``"main"``) fall back to a per-segment ``(type_rank, value)`` tuple and are
+    ranked below every well-formed version.
+
+    Wrapping both cases behind a leading discriminator (``1`` for parsed
+    versions, ``0`` for the fallback) guarantees the resulting keys are always
+    comparable, avoiding
+    ``TypeError: '<' not supported between instances of 'str' and 'int'`` that
+    a naive ``[int(x) if x.isdigit() else x, ...]`` key raises whenever a
+    numeric segment (``0.5.14`` -> ``14``) has to be compared against a mixed
+    segment (``0.5.10rc0`` -> ``"10rc0"``) at the same position.
+
+    Args:
+        version:
+            The version string, e.g. "0.10.0", "0.5.10rc0", "2.1.rc1", "latest".
+
+    Returns:
+        A comparable sort key. Larger keys correspond to newer versions, so
+        ``sorted(..., reverse=True)`` yields newest-first ordering.
+
+    """
+    try:
+        return (1, Version(version))
+    except InvalidVersion:
+        return (
+            0,
+            [(0, int(x)) if x.isdigit() else (1, x) for x in version.split(".")],
+        )
 
 
 @dataclass_json
@@ -598,9 +638,7 @@ def build_backend_runners(
     results.sort(key=lambda br: br.backend)
     for backend in results:
         backend.versions.sort(
-            key=lambda bv: [
-                int(x) if x.isdigit() else x for x in bv.version.split(".")
-            ],
+            key=lambda bv: version_sort_key(bv.version),
             reverse=True,
         )
         for version in backend.versions:
@@ -609,9 +647,7 @@ def build_backend_runners(
                 variant.services.sort(key=lambda s: s.service)
                 for service in variant.services:
                     service.versions.sort(
-                        key=lambda sv: [
-                            int(x) if x.isdigit() else x for x in sv.version.split(".")
-                        ],
+                        key=lambda sv: version_sort_key(sv.version),
                         reverse=True,
                     )
                     for service_version in service.versions:
@@ -772,18 +808,14 @@ def build_service_runners(
     results.sort(key=lambda sr: sr.service)
     for service in results:
         service.versions.sort(
-            key=lambda sv: [
-                int(x) if x.isdigit() else x for x in sv.version.split(".")
-            ],
+            key=lambda sv: version_sort_key(sv.version),
             reverse=True,
         )
         for service_version in service.versions:
             service_version.backends.sort(key=lambda b: b.backend)
             for backend in service_version.backends:
                 backend.versions.sort(
-                    key=lambda bv: [
-                        int(x) if x.isdigit() else x for x in bv.version.split(".")
-                    ],
+                    key=lambda bv: version_sort_key(bv.version),
                     reverse=True,
                 )
                 for backend_version in backend.versions:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ classifiers = [
 dependencies = [
     "argcomplete>=3.6.3",
     "dataclasses-json>=0.6.7",
+    "packaging>=21.0",
     "requests>=2.32.3",
 ]
 dynamic = ["version"]

--- a/tests/gpustack_runner/test_runner.py
+++ b/tests/gpustack_runner/test_runner.py
@@ -7,6 +7,127 @@ from gpustack_runner import (
     list_runners,
     list_service_runners,
 )
+from gpustack_runner.runner import version_sort_key
+
+
+@pytest.mark.parametrize(
+    "name, versions, expected",
+    [
+        # Pure numeric versions must sort by value, not lexicographically,
+        # so double-digit patch/minor segments outrank single-digit ones.
+        (
+            "numeric patch double digit",
+            ["0.5.2", "0.5.10", "0.5.9", "0.5.12", "0.5.14"],
+            ["0.5.14", "0.5.12", "0.5.10", "0.5.9", "0.5.2"],
+        ),
+        (
+            "numeric minor rolls over ten",
+            ["0.9.0", "0.10.0", "0.2.0", "1.0.0"],
+            ["1.0.0", "0.10.0", "0.9.0", "0.2.0"],
+        ),
+        (
+            "four segment versions",
+            ["0.10.0", "0.10.1.1", "0.10.2", "0.9.2"],
+            ["0.10.2", "0.10.1.1", "0.10.0", "0.9.2"],
+        ),
+        # Regression for gpustack/gpustack#5792: a segment gluing digits and
+        # letters together (``10rc0``) must not raise TypeError when compared
+        # against pure-numeric segments (``14``) at the same position.
+        (
+            "glued prerelease among numeric (issue 5792)",
+            [
+                "0.5.2",
+                "0.5.6",
+                "0.5.7",
+                "0.5.9",
+                "0.5.10",
+                "0.5.10rc0",
+                "0.5.12",
+                "0.5.14",
+                "0.5.4.post3",
+                "0.5.5.post3",
+                "0.5.6.post2",
+                "0.5.8.post1",
+                "0.5.12.post1",
+                "0.5.1.post3",
+            ],
+            [
+                "0.5.14",
+                "0.5.12.post1",
+                "0.5.12",
+                "0.5.10",
+                "0.5.10rc0",
+                "0.5.9",
+                "0.5.8.post1",
+                "0.5.7",
+                "0.5.6.post2",
+                "0.5.6",
+                "0.5.5.post3",
+                "0.5.4.post3",
+                "0.5.2",
+                "0.5.1.post3",
+            ],
+        ),
+        # A pre-release must sort *before* its final release, and post-releases
+        # *after* it (PEP 440 ordering).
+        (
+            "prerelease ranks below final release",
+            ["0.5.10", "0.5.10rc0", "0.5.10rc1"],
+            ["0.5.10", "0.5.10rc1", "0.5.10rc0"],
+        ),
+        (
+            "post release ranks above final release",
+            ["1.0.0", "1.0.0.post1", "1.0.0.post2"],
+            ["1.0.0.post2", "1.0.0.post1", "1.0.0"],
+        ),
+        # mindie-style ``X.Y.rcN`` (rc split onto its own segment) also parses.
+        (
+            "mindie rc versions",
+            ["2.1.rc1", "2.1.rc2", "2.2.rc1", "2.3.0"],
+            ["2.3.0", "2.2.rc1", "2.1.rc2", "2.1.rc1"],
+        ),
+        # Non-PEP440 tags never raise and rank below every real version.
+        (
+            "unparseable tags only",
+            ["latest", "main", "stable"],
+            ["stable", "main", "latest"],
+        ),
+        (
+            "real versions outrank tags",
+            ["1.0.0", "latest", "0.9.0"],
+            ["1.0.0", "0.9.0", "latest"],
+        ),
+        (
+            "single segment",
+            ["7"],
+            ["7"],
+        ),
+    ],
+)
+def test_version_sort_key(name, versions, expected):
+    actual = sorted(versions, key=version_sort_key, reverse=True)
+    assert actual == expected, f"case {name} expected {expected}, but got {actual}"
+
+
+def test_build_runners_sort_bundled_catalog_without_error():
+    """
+    Building runners over the bundled catalog must not raise, guarding against
+    gpustack/gpustack#5792 where a real catalog entry (``sglang 0.5.10rc0``)
+    made the internal version sort throw
+    ``TypeError: '<' not supported between instances of 'str' and 'int'``.
+
+    ``list_backend_runners`` and ``list_service_runners`` perform every version
+    sort the build functions rely on, so a clean call exercises them all.
+    """
+    # Both entrypoints are ``@lru_cache``d; clear them so the version-sorting
+    # code paths actually run instead of returning a cached result from an
+    # earlier test in the session.
+    list_backend_runners.cache_clear()
+    list_service_runners.cache_clear()
+    backend_runners = list_backend_runners(todict=True)
+    service_runners = list_service_runners(todict=True)
+    assert backend_runners, "expected a non-empty backend runner catalog"
+    assert service_runners, "expected a non-empty service runner catalog"
 
 
 @pytest.mark.parametrize(

--- a/uv.lock
+++ b/uv.lock
@@ -198,6 +198,7 @@ source = { editable = "." }
 dependencies = [
     { name = "argcomplete" },
     { name = "dataclasses-json" },
+    { name = "packaging" },
     { name = "requests" },
 ]
 
@@ -218,6 +219,7 @@ dev = [
 requires-dist = [
     { name = "argcomplete", specifier = ">=3.6.3" },
     { name = "dataclasses-json", specifier = ">=0.6.7" },
+    { name = "packaging", specifier = ">=21.0" },
     { name = "requests", specifier = ">=2.32.3" },
 ]
 


### PR DESCRIPTION
The version sort key mapped each dotted segment to `int(x) if x.isdigit() else x`, producing mixed int/str lists. When a group contained a segment gluing digits and letters together (e.g. sglang `0.5.10rc0` -> `"10rc0"`) next to pure-numeric siblings (`0.5.14` -> `14`), comparing them raised `TypeError: '<' not supported between instances of 'str' and 'int'`, crashing GET /v2/inference-backends (gpustack/gpustack#5792).

Replace the key with `packaging.version.Version`, which sorts by PEP 440 semantics (numeric ordering, and pre-releases ranked below their final release). Non-PEP440 tags (`latest`, `main`) fall back to a per-segment tuple key and rank below every real version, so keys are always comparable and the sort never raises.

- add `packaging` as a direct dependency
- add parametrized version-sort cases (double-digit ordering, the #5792 glued pre-release, rc/post semantics, unparseable tags) and a catalog regression test

https://github.com/gpustack/gpustack/issues/5792