### PR TITLE
chore: make src-registry required in copy workflow

### DIFF
--- a/.github/workflows/copy.yml
+++ b/.github/workflows/copy.yml
@@ -20,7 +20,7 @@ on:
     inputs:
       src-registry:
         description: 'Source Docker registry.'
-        required: false
+        required: true
         default: 'docker.io'
         type: string
       src-image:


### PR DESCRIPTION
Mark the source image registry of the copy workflow as required, making it clearer and less confusing when filling in inputs.