### PR TITLE
CRITICAL: Revert "feat: add gguff plugin to vllm runtime (#222)"

### DIFF
--- a/pack/cuda/Dockerfile.vllm
+++ b/pack/cuda/Dockerfile.vllm
@@ -7,7 +7,6 @@ ARG VLLM_VERSION=0.25.0
 ARG VLLM_TORCH_VERSION=2.11.0
 ARG VLLM_TORCH_CUDA_VERSION=${CUDA_VERSION}
 ARG VLLM_OMNI_COMMIT=d3c47ef
-ARG VLLM_GGUF_PLUGIN_VERSION=0.0.3
 
 FROM ${VLLM_BASE_IMAGE} AS vllm-build
 SHELL ["/bin/bash", "-eo", "pipefail", "-c"]
@@ -195,7 +194,6 @@ SHELL ["/bin/bash", "-eo", "pipefail", "-c"]
 ARG TARGETPLATFORM
 ARG TARGETOS
 ARG TARGETARCH
-ARG VLLM_GGUF_PLUGIN_VERSION
 
 ## Install Ray
 
@@ -286,7 +284,6 @@ RUN <<EOF
     # Review
     uv pip tree \
         --package vllm \
-        --package vllm-gguf-plugin \
         --package vllm-omni \
         --package flashinfer-python \
         --package torch \
@@ -310,20 +307,6 @@ RUN --mount=type=bind,target=/workspace,rw <<EOF
         pushd $(pip show vllm_omni | grep Location: | cut -d" " -f 2) \
             && patch -p1 < /workspace/patches/vllm_omni/*.patch; \
     fi
-EOF
-
-## Install GGUF
-
-RUN <<EOF
-    # GGUF
-    # https://docs.vllm.ai/en/v0.24.0/features/quantization/gguf/
-
-    uv pip install \
-        vllm-gguf-plugin==${VLLM_GGUF_PLUGIN_VERSION}
-
-    # Cleanup
-    rm -rf /var/tmp/* \
-        && rm -rf /tmp/*
 EOF
 
 ## Dependencies

--- a/pack/rocm/Dockerfile.vllm
+++ b/pack/rocm/Dockerfile.vllm
@@ -9,7 +9,6 @@ ARG VLLM_TORCH_ROCM_VERSION=${ROCM_VERSION}
 ARG VLLM_LMCACHE_VERSION=0.5.0
 ARG VLLM_MOONCAKE_VERSION=0.3.11.post1
 ARG VLLM_OMNI_COMMIT=d3c47ef
-ARG VLLM_GGUF_PLUGIN_VERSION=0.0.3
 
 FROM ${VLLM_BASE_IMAGE} AS vllm-build
 SHELL ["/bin/bash", "-eo", "pipefail", "-c"]
@@ -314,7 +313,6 @@ SHELL ["/bin/bash", "-eo", "pipefail", "-c"]
 ARG TARGETPLATFORM
 ARG TARGETOS
 ARG TARGETARCH
-ARG VLLM_GGUF_PLUGIN_VERSION
 
 ## Install Ray
 
@@ -401,7 +399,6 @@ RUN <<EOF
     # Review
     uv pip tree \
         --package vllm \
-        --package vllm-gguf-plugin \
         --package vllm-omni \
         --package flash-attn \
         --package triton \
@@ -424,20 +421,6 @@ RUN --mount=type=bind,target=/workspace,rw <<EOF
         pushd $(pip show vllm_omni | grep Location: | cut -d" " -f 2) \
             && patch -p1 < /workspace/patches/vllm_omni/*.patch; \
     fi
-EOF
-
-## Install GGUF
-
-RUN <<EOF
-    # GGUF
-    # https://docs.vllm.ai/en/v0.24.0/features/quantization/gguf/
-
-    uv pip install \
-        vllm-gguf-plugin==${VLLM_GGUF_PLUGIN_VERSION}
-
-    # Cleanup
-    rm -rf /var/tmp/* \
-        && rm -rf /tmp/*
 EOF
 
 ## Dependencies


### PR DESCRIPTION
This reverts commit 08928a25098914f3330e934966a7fa0e8ac93bac. Remove [vllm-gguf-plugin](https://github.com/vllm-project/vllm-gguf-plugin)

Current [vllm-gguf-plugin](https://github.com/vllm-project/vllm-gguf-plugin) doens't work with actual vllm

Error:

```
2026-07-13 16:01:24.616572+08:00 - gpustack.worker.backends.base - INFO - Preparing model files...
2026-07-13 16:01:24.627295+08:00 - gpustack.worker.backends.base - INFO - Model files are ready.
2026-07-13 16:01:24.627367+08:00 - gpustack.worker.serve_manager - INFO - Provisioning model instance qwen3.6-27b-W8A16-2x-v1-jrSjI
2026-07-13 16:01:24.627404+08:00 - gpustack.worker.backends.vllm - INFO - Starting vLLM model instance: qwen3.6-27b-W8A16-2x-v1-jrSjI
2026-07-13 16:01:24.662106+08:00 - gpustack.worker.backends.vllm - INFO - Creating vLLM container workload: qwen3.6-27b-W8A16-2x-v1-jrSjI
2026-07-13 16:01:24.662183+08:00 - gpustack.worker.backends.vllm - INFO - With image: gpustack/runner:cuda13.0-vllm0.25.0-dev, command: [vllm serve /var/lib/gpustack/cache/huggingface/groxaxo/Qwen3.6-27B-W8A16-AutoRound --speculative-config {"method": "mtp", "num_speculative_tokens": 3} --disable-access-log-for-endpoints /metrics --enable-prompt-tokens-details --max-model-len=128000 --dtype=half --tensor-parallel-size=2 --reasoning-parser=qwen3 --gpu-memory-utilization=0.95 --enable-auto-tool-choice --tool-call-parser=qwen3_coder --max-num-batched-tokens=6144 --max-num-seqs=12 -O3 --override-generation-config={"temperature": 0.6, "top_p": 0.95, "top_k": 20, "min_p": 0.0, "presence_penalty": 0.0, "repetition_penalty": 1.0} --default-chat-template-kwargs {"enable_thinking": false} --performance_mode=balanced --trust-remote-code --enable-chunked-prefill --enable-prefix-caching --no-disable-cascade-attn --mm-processor-cache-gb 0 --renderer-num-workers 4 --disable-custom-all-reduce --host 192.168.0.44 --port 40043 --served-model-name qwen3.6-27b-W8A16-2x-v1], arguments: [], ports: [40043], envs(inconsistent input items mean unchangeable):
NCCL_P2P_DISABLE=1
OMP_NUM_THREADS=12
PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True
RUNAI_STREAMER_LOG_LEVEL=INFO
RUNAI_STREAMER_LOG_TO_STDERR=1
RUNAI_STREAMER_MEMORY_LIMIT=0
SAFETENSORS_FAST_GPU=1
VLLM_CACHE_ROOT=/var/lib/gpustack/cache/vllm
VLLM_USE_FASTOKENS=1
2026-07-13 16:01:24.699065+08:00 - 440365 - gpustack_runtime.deployer.docker - INFO - Mirrored deployment enabled, using self Container 01e3ade9c09b for options mirroring
2026-07-13 16:01:25.536205+08:00 - gpustack.worker.backends.vllm - INFO - Created vLLM container workload: qwen3.6-27b-W8A16-2x-v1-jrSjI
2026-07-13 16:01:25.536480+08:00 - gpustack.worker.serve_manager - INFO - Finished provisioning model instance qwen3.6-27b-W8A16-2x-v1-jrSjI
INFO 07-13 16:01:57 [patch.py:252] NVFP4 W4A4 weight_scale NaN-clamp: installed.
INFO 07-13 16:01:57 [patch.py:483] [cumem-cuda] CuMemAllocator._python_free_callback patched: asleep guard extended to all platforms.
INFO 07-13 16:01:58 [__init__.py:112] Registered model loader `<class 'vllm_gguf_plugin.loader.GGUFModelLoader'>` with load format `gguf`
INFO 07-13 16:01:58 [config.py:421] Registered config parser `<class 'vllm_gguf_plugin.config_parser.GGUFConfigParser'>` with config format `gguf`
(APIServer pid=1) INFO 07-13 16:02:01 [api_utils.py:339] 
(APIServer pid=1) INFO 07-13 16:02:01 [api_utils.py:339]        █     █     █▄   ▄█
(APIServer pid=1) INFO 07-13 16:02:01 [api_utils.py:339]  ▄▄ ▄█ █     █     █ ▀▄▀ █  version 0.25.0
(APIServer pid=1) INFO 07-13 16:02:01 [api_utils.py:339]   █▄█▀ █     █     █     █  model   /var/lib/gpustack/cache/huggingface/groxaxo/Qwen3.6-27B-W8A16-AutoRound
(APIServer pid=1) INFO 07-13 16:02:01 [api_utils.py:339]    ▀▀  ▀▀▀▀▀ ▀▀▀▀▀ ▀     ▀
(APIServer pid=1) INFO 07-13 16:02:01 [api_utils.py:339] 
(APIServer pid=1) INFO 07-13 16:02:01 [api_utils.py:273] non-default args: {'model_tag': '/var/lib/gpustack/cache/huggingface/groxaxo/Qwen3.6-27B-W8A16-AutoRound', 'default_chat_template_kwargs': {'enable_thinking': False}, 'enable_auto_tool_choice': True, 'tool_call_parser': 'qwen3_coder', 'enable_prompt_tokens_details': True, 'host': '192.168.0.44', 'port': 40043, 'disable_access_log_for_endpoints': '/metrics', 'model': '/var/lib/gpustack/cache/huggingface/groxaxo/Qwen3.6-27B-W8A16-AutoRound', 'trust_remote_code': True, 'dtype': 'half', 'max_model_len': 128000, 'disable_cascade_attn': False, 'served_model_name': ['qwen3.6-27b-W8A16-2x-v1'], 'override_generation_config': {'temperature': 0.6, 'top_p': 0.95, 'top_k': 20, 'min_p': 0.0, 'presence_penalty': 0.0, 'repetition_penalty': 1.0}, 'renderer_num_workers': 4, 'reasoning_parser': 'qwen3', 'tensor_parallel_size': 2, 'disable_custom_all_reduce': True, 'gpu_memory_utilization': 0.95, 'enable_prefix_caching': True, 'mm_processor_cache_gb': 0.0, 'max_num_batched_tokens': 6144, 'max_num_seqs': 12, 'enable_chunked_prefill': True, 'speculative_config': {'method': 'mtp', 'num_speculative_tokens': 3}, 'optimization_level': '3'}
(APIServer pid=1) WARNING 07-13 16:02:01 [envs.py:2041] Unknown vLLM environment variable detected: VLLM_BUILD_COMMIT
(APIServer pid=1) WARNING 07-13 16:02:01 [envs.py:2041] Unknown vLLM environment variable detected: VLLM_BUILD_PIPELINE
(APIServer pid=1) WARNING 07-13 16:02:01 [envs.py:2041] Unknown vLLM environment variable detected: VLLM_BUILD_URL
(APIServer pid=1) WARNING 07-13 16:02:01 [envs.py:2041] Unknown vLLM environment variable detected: VLLM_IMAGE_TAG
(APIServer pid=1) WARNING 07-13 16:02:01 [envs.py:2041] Unknown vLLM environment variable detected: VLLM_VERSION
(APIServer pid=1) WARNING 07-13 16:02:01 [envs.py:2041] Unknown vLLM environment variable detected: VLLM_TORCH_VERSION
(APIServer pid=1) WARNING 07-13 16:02:01 [envs.py:2041] Unknown vLLM environment variable detected: VLLM_TORCH_CUDA_VERSION
(APIServer pid=1) INFO 07-13 16:02:17 [model.py:619] Resolved architecture: Qwen3_5ForConditionalGeneration
(APIServer pid=1) WARNING 07-13 16:02:17 [model.py:2114] Casting torch.bfloat16 to torch.float16.
(APIServer pid=1) INFO 07-13 16:02:17 [model.py:1776] Using max model len 128000
(APIServer pid=1) Traceback (most recent call last):
(APIServer pid=1)   File "/usr/local/bin/vllm", line 10, in <module>
(APIServer pid=1)     sys.exit(main())
(APIServer pid=1)              ^^^^^^
(APIServer pid=1)   File "/usr/local/lib/python3.12/dist-packages/vllm/entrypoints/cli/main.py", line 95, in main
(APIServer pid=1)     args.dispatch_function(args)
(APIServer pid=1)   File "/usr/local/lib/python3.12/dist-packages/vllm/entrypoints/cli/serve.py", line 148, in cmd
(APIServer pid=1)     uvloop.run(run_server(args))
(APIServer pid=1)   File "/usr/local/lib/python3.12/dist-packages/uvloop/__init__.py", line 96, in run
(APIServer pid=1)     return __asyncio.run(
(APIServer pid=1)            ^^^^^^^^^^^^^^
(APIServer pid=1)   File "/usr/lib/python3.12/asyncio/runners.py", line 194, in run
(APIServer pid=1)     return runner.run(main)
(APIServer pid=1)            ^^^^^^^^^^^^^^^^
(APIServer pid=1)   File "/usr/lib/python3.12/asyncio/runners.py", line 118, in run
(APIServer pid=1)     return self._loop.run_until_complete(task)
(APIServer pid=1)            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(APIServer pid=1)   File "uvloop/loop.pyx", line 1518, in uvloop.loop.Loop.run_until_complete
(APIServer pid=1)   File "/usr/local/lib/python3.12/dist-packages/uvloop/__init__.py", line 48, in wrapper
(APIServer pid=1)     return await main
(APIServer pid=1)            ^^^^^^^^^^
(APIServer pid=1)   File "/usr/local/lib/python3.12/dist-packages/vllm/entrypoints/openai/api_server.py", line 698, in run_server
(APIServer pid=1)     await run_server_worker(listen_address, sock, args, **uvicorn_kwargs)
(APIServer pid=1)   File "/usr/local/lib/python3.12/dist-packages/vllm/entrypoints/openai/api_server.py", line 712, in run_server_worker
(APIServer pid=1)     async with build_async_engine_client(
(APIServer pid=1)   File "/usr/lib/python3.12/contextlib.py", line 210, in __aenter__
(APIServer pid=1)     return await anext(self.gen)
(APIServer pid=1)            ^^^^^^^^^^^^^^^^^^^^^
(APIServer pid=1)   File "/usr/local/lib/python3.12/dist-packages/vllm/entrypoints/openai/api_server.py", line 100, in build_async_engine_client
(APIServer pid=1)     async with build_async_engine_client_from_engine_args(
(APIServer pid=1)   File "/usr/lib/python3.12/contextlib.py", line 210, in __aenter__
(APIServer pid=1)     return await anext(self.gen)
(APIServer pid=1)            ^^^^^^^^^^^^^^^^^^^^^
(APIServer pid=1)   File "/usr/local/lib/python3.12/dist-packages/vllm/entrypoints/openai/api_server.py", line 124, in build_async_engine_client_from_engine_args
(APIServer pid=1)     vllm_config = engine_args.create_engine_config(usage_context=usage_context)
(APIServer pid=1)                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(APIServer pid=1)   File "/usr/local/lib/python3.12/dist-packages/vllm/engine/arg_utils.py", line 1851, in create_engine_config
(APIServer pid=1)     model_config = self.create_model_config()
(APIServer pid=1)                    ^^^^^^^^^^^^^^^^^^^^^^^^^^
(APIServer pid=1)   File "/usr/local/lib/python3.12/dist-packages/vllm_gguf_plugin/plugin.py", line 76, in create_model_config
(APIServer pid=1)     return original_create_model_config(self, *args, **kwargs)
(APIServer pid=1)            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(APIServer pid=1)   File "/usr/local/lib/python3.12/dist-packages/vllm/engine/arg_utils.py", line 1614, in create_model_config
(APIServer pid=1)     return ModelConfig(
(APIServer pid=1)            ^^^^^^^^^^^^
(APIServer pid=1)   File "/usr/local/lib/python3.12/dist-packages/pydantic/_internal/_dataclasses.py", line 121, in __init__
(APIServer pid=1)     s.__pydantic_validator__.validate_python(ArgsKwargs(args, kwargs), self_instance=s)
(APIServer pid=1)   File "/usr/local/lib/python3.12/dist-packages/vllm/config/model.py", line 744, in __post_init__
(APIServer pid=1)     self._verify_quantization()
(APIServer pid=1)   File "/usr/local/lib/python3.12/dist-packages/vllm/config/model.py", line 1064, in _verify_quantization
(APIServer pid=1)     quantization_override = method.override_quantization_method(
(APIServer pid=1)                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(APIServer pid=1) TypeError: GGUFConfig.override_quantization_method() got an unexpected keyword argument 'hf_config'
```