### PR TITLE
fix: deduplicate CuPy installation for sglang in Dockerfile

### DIFF
--- a/pack/cuda/Dockerfile.sglang
+++ b/pack/cuda/Dockerfile.sglang
@@ -341,6 +341,39 @@ EOT
         && rm -rf /tmp/*
 EOF
 
+## Deduplicate CuPy
+
+RUN <<EOF
+    # CuPy
+    # Our lmcache 0.4.4 hardcodes cupy-cuda12x (requirements/cuda_core.txt, CUDA-agnostic)
+    # while the base's MSCCL++ ships cupy-cuda13x on cu130 (mscclpp[cuda13], added upstream
+    # at sglang 0.5.14); both share the same cupy/ tree, so uninstalling one breaks the
+    # other. Purge both, then reinstall only the variant matching the CUDA major we build
+    # for, at the version already present in the image. On cu129 both sources are cupy-cuda12x
+    # (mscclpp[cuda12] + lmcache) so this collapses to a harmless single-variant reinstall.
+
+    IFS="." read -r CUDA_MAJOR CUDA_MINOR CUDA_PATCH <<< "${CUDA_VERSION}"
+    PLATLIB="$(python -c 'import sysconfig; print(sysconfig.get_paths()["platlib"])')"
+    CUPY="cupy-cuda${CUDA_MAJOR}x"
+    CUPY_VER="$(uv pip show ${CUPY} 2>/dev/null | awk '/^Version:/{print $2}' || true)"
+    uv pip uninstall cupy-cuda12x cupy-cuda13x || true
+    rm -rf "${PLATLIB}"/cupy "${PLATLIB}"/cupyx "${PLATLIB}"/cupy_backends
+    # Reuse the version already resolved in the image and install only the CUDA-matching
+    # variant. Fail loudly if that variant is absent, rather than installing an unpinned latest.
+    if [[ -z "${CUPY_VER}" ]]; then
+        echo "${CUPY} not found in image; refusing to install unpinned cupy" >&2
+        exit 1
+    fi
+    uv pip install "${CUPY}==${CUPY_VER}"
+
+    # Review
+    uv pip show "${CUPY}"
+
+    # Cleanup
+    rm -rf /var/tmp/* \
+        && rm -rf /tmp/*
+EOF
+
 ## Postprocess
 
 RUN <<EOF

--- a/pack/cuda/Dockerfile.vllm
+++ b/pack/cuda/Dockerfile.vllm
@@ -256,11 +256,11 @@ RUN <<EOF
     # so cu129 also gets that pinned version instead of ray's unconstrained cupy-cuda12x.
 
     IFS="." read -r CUDA_MAJOR CUDA_MINOR CUDA_PATCH <<< "${CUDA_VERSION}"
-    PURELIB="$(python -c 'import sysconfig; print(sysconfig.get_paths()["purelib"])')"
+    PLATLIB="$(python -c 'import sysconfig; print(sysconfig.get_paths()["platlib"])')"
     CUPY="cupy-cuda${CUDA_MAJOR}x"
     CUPY_VER="$(uv pip show cupy-cuda13x 2>/dev/null | awk '/^Version:/{print $2}' || true)"
     uv pip uninstall cupy-cuda12x cupy-cuda13x || true
-    rm -rf "${PURELIB}"/cupy "${PURELIB}"/cupyx "${PURELIB}"/cupy_backends
+    rm -rf "${PLATLIB}"/cupy "${PLATLIB}"/cupyx "${PLATLIB}"/cupy_backends
     # cupy-cuda12x and cupy-cuda13x share the same version number, so reuse the base's
     # pinned version and install only the variant matching the CUDA major we build for.
     # Fail loudly if the base no longer ships cupy, rather than installing an unpinned latest.
@@ -271,7 +271,7 @@ RUN <<EOF
     uv pip install "${CUPY}==${CUPY_VER}"
 
     # Review
-    uv pip list | grep -i cupy
+    uv pip show "${CUPY}"
 
     # Cleanup
     rm -rf /var/tmp/* \


### PR DESCRIPTION
lmcache pulls in cupy-12x, but sglang ≥0.5.14 brings mscclpp which needs cupy-13x. We should reconcile both the way vLLM does

<img width="1320" height="1102" alt="image" src="https://github.com/user-attachments/assets/f5b7e44b-48a7-4819-9f10-71636e6e578a" />
