### PR TITLE
feat(pack): add Enflame GCU (燧原 S60) backend support

### DIFF
--- a/PR_TEMPLATE.md
+++ b/PR_TEMPLATE.md
@@ -1,0 +1,86 @@
+# feat(pack): add Enflame GCU (燧原 S60) backend support
+
+## Summary
+
+Add Dockerfile support for Enflame GCU (燧原 S60) to the GPUStack runner pack system.
+
+## Changes
+
+- **New directory**: `pack/gcu/`
+  - `Dockerfile` — Combined build with vanilla → runtime → vllm stages
+  - `Dockerfile.vllm` — Per-service vLLM Dockerfile (runtime + vllm targets)
+- **Modified**: `pack/matrix.yaml` — Added `gcu` backend rule
+
+## Version Information
+
+| Component | Version |
+|-----------|---------|
+| TopsRider (燧原加速框架) | 3.7.107 (i3x 3.6+) |
+| vLLM-GCU | 0.11.0 |
+| Python | 3.10 |
+| OS | Ubuntu 22.04 |
+| Hardware | S60 GCU |
+
+## Vanilla Image
+
+```
+registry-egc.enflame-tech.com/artifacts/vllm_gcu:v0.11.0-TR3.7.107-ubuntu2204
+```
+
+This image is provided by Enflame and includes:
+- Enflame GCU driver and TopsRider SDK
+- `torch_gcu` (PyTorch for GCU)
+- `vllm-gcu` (vLLM with GCU backend)
+- `triton_gcu`
+
+## Expected Image Tags
+
+After the copy.yml workflow runs and the Dockerfiles are built:
+
+| Stage | Tag |
+|-------|-----|
+| Vanilla | `gpustack/runner:gcu3.7.107-python3.10-vanilla` |
+| Runtime | `gpustack/runner:gcu3.7.107-python3.10` |
+| vLLM | `gpustack/runner:gcu3.7.107-vllm0.11.0-python3.10` |
+
+## copy.yml Parameters
+
+For the GitHub Action `copy.yml`, the suggested inputs:
+
+```
+src-registry: registry-egc.enflame-tech.com
+src-image: artifacts/vllm_gcu:v0.11.0-TR3.7.107-ubuntu2204
+dst-image-tag: gcu3.7.107-python3.10
+```
+
+## Build & Test
+
+To build the runtime image locally:
+```bash
+docker build --progress=plain --platform=linux/amd64 \
+  --file=pack/gcu/Dockerfile \
+  --tag=gpustack/runner:gcu3.7.107-python3.10 \
+  --target=runtime \
+  pack/gcu
+```
+
+To build the vLLM image:
+```bash
+docker build --progress=plain --platform=linux/amd64 \
+  --file=pack/gcu/Dockerfile \
+  --tag=gpustack/runner:gcu3.7.107-vllm0.11.0-python3.10 \
+  --target=vllm \
+  pack/gcu
+```
+
+## Notes
+
+- Only vLLM backend is supported (SGLang support not yet available for GCU)
+- The vanilla image is Ubuntu 22.04 based
+- Device visibility env var: `GCU_VISIBLE_DEVICES`
+- Uses `RAY_EXPERIMENTAL_NOSET_GCU_VISIBLE_DEVICES=1` in entrypoint
+
+## Related
+
+- vLLM-GCU upstream: https://github.com/EnflameTechnology/vllm-gcu
+- Enflame official: https://www.enflame-tech.com/

--- a/pack/gcu/Dockerfile
+++ b/pack/gcu/Dockerfile
@@ -1,0 +1,328 @@
+# syntax=docker/dockerfile:1
+
+# GPUStack Runner - Enflame GCU (燧原 S60) Pack
+#
+# This Dockerfile builds the runtime layer for Enflame GCU acceleration.
+#
+# Package logic:
+# 1. vanilla stage:
+#    - No-op placeholder. The vanilla image is provided by Enflame.
+#    - Tag convention: gpustack/runner:gcu${GCU_VERSION}${GCU_VERSION_EXTRA}-python${PYTHON_VERSION}-vanilla
+# 2. runtime stage:
+#    - Install common tools, buildkit, and declare environment variables.
+# 3. vllm stage:
+#    - Use the pre-installed vLLM from the vanilla image.
+#
+# Argument usage:
+# - PYTHON_VERSION: Version of Python to use.
+# - GCU_VERSION: Version of Enflame TopsRider GCU runtime environment to use.
+# - GCU_VERSION_EXTRA: Extra version string for Enflame TopsRider.
+# - GCU_ARCHS: Arch variant (e.g., s60).
+# - VLLM_BASE_IMAGE: Base (vanilla) image for vLLM.
+# - VLLM_VERSION: Version of vLLM to use.
+# - SGLANG_BASE_IMAGE: Base (vanilla) image for SGLang.
+# - SGLANG_VERSION: Version of SGLang to use.
+
+ARG PYTHON_VERSION=3.10
+ARG GCU_VERSION=3.7.107
+ARG GCU_VERSION_EXTRA
+ARG GCU_ARCHS=s60
+
+# Vanilla image is provided by Enflame.
+# Example: registry-egc.enflame-tech.com/artifacts/vllm_gcu:v0.11.0-TR3.7.107-ubuntu2204
+# The copy.yml workflow copies this to gpustack/runner:gcu{VERSION}{EXTRA}-python{PYTHON}-vanilla
+ARG VANILLA_IMAGE=gpustack/runner:gcu${GCU_VERSION}${GCU_VERSION_EXTRA}-python${PYTHON_VERSION}-vanilla
+
+# vLLM / SGLang defaults
+ARG VLLM_BASE_IMAGE=${VANILLA_IMAGE}
+ARG VLLM_VERSION=0.11.0
+ARG SGLANG_BASE_IMAGE=${VANILLA_IMAGE}
+ARG SGLANG_VERSION=0.5.0
+
+# ============================================================
+# Stage: vanilla (placeholder)
+# ============================================================
+# The vanilla image is copied from Enflame's registry via the
+# copy.yml GitHub Action. No Dockerfile stage is needed here;
+# it is simply the source image.
+
+# ============================================================
+# Stage: runtime
+# ============================================================
+
+FROM ${VANILLA_IMAGE} AS runtime
+SHELL ["/bin/bash", "-eo", "pipefail", "-c"]
+
+ARG TARGETPLATFORM
+ARG TARGETOS
+ARG TARGETARCH
+
+## Install tools
+
+ENV DEBIAN_FRONTEND=noninteractive \
+    LANG='en_US.UTF-8' \
+    LANGUAGE='en_US:en' \
+    LC_ALL='en_US.UTF-8'
+
+RUN <<EOF
+    # Tools
+
+    # Refresh
+    apt-get update -y && apt-get install -y --no-install-recommends \
+        software-properties-common apt-transport-https \
+        ca-certificates gnupg2 lsb-release gnupg-agent \
+      && apt-get update -y \
+      && add-apt-repository -y ppa:ubuntu-toolchain-r/test \
+      && apt-get update -y
+
+    # Install
+    apt-get install -y --no-install-recommends \
+        ca-certificates build-essential binutils bash openssl \
+        curl wget aria2 \
+        git git-lfs \
+        unzip xz-utils \
+        tzdata locales \
+        iproute2 iputils-ping ifstat net-tools dnsutils pciutils ipmitool \
+        rdma-core rdmacm-utils infiniband-diags \
+        procps sysstat htop \
+        tini vim jq bc tree
+
+    # Update locale
+    localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
+
+    # Update timezone
+    rm -f /etc/localtime \
+        && ln -sf /usr/share/zoneinfo/Asia/Shanghai /etc/localtime \
+        && echo "Asia/Shanghai" > /etc/timezone \
+        && dpkg-reconfigure --frontend noninteractive tzdata
+
+    # Cleanup
+    rm -rf /var/tmp/* \
+        && rm -rf /tmp/* \
+        && rm -rf /var/cache/apt
+EOF
+
+## Upgrade GCC if needed
+
+RUN <<EOF
+    # GCC
+
+    # Upgrade GCC if the Ubuntu version is lower than 21.04.
+    source /etc/os-release
+    if (( $(echo "${VERSION_ID} > 21.04" | bc -l) )); then
+        echo "Skipping GCC upgrade for ${VERSION_ID}..."
+        exit 0
+    fi
+
+    # Install
+    apt-get install -y --no-install-recommends \
+        gcc-11 g++-11 gfortran-11 gfortran
+
+    # Update alternatives
+    if [[ -f /etc/alternatives/gcov-dump ]]; then update-alternatives --remove-all gcov-dump; fi; update-alternatives --install /usr/bin/gcov-dump gcov-dump /usr/bin/gcov-dump-11 10
+    if [[ -f /etc/alternatives/lto-dump ]]; then update-alternatives --remove-all lto-dump; fi; update-alternatives --install /usr/bin/lto-dump lto-dump /usr/bin/lto-dump-11 10
+    if [[ -f /etc/alternatives/gcov ]]; then update-alternatives --remove-all gcov; fi; update-alternatives --install /usr/bin/gcov gcov /usr/bin/gcov-11 10
+    if [[ -f /etc/alternatives/gcc ]]; then update-alternatives --remove-all gcc; fi; update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-11 10
+    if [[ -f /etc/alternatives/gcc-nm ]]; then update-alternatives --remove-all gcc-nm; fi; update-alternatives --install /usr/bin/gcc-nm gcc-nm /usr/bin/gcc-nm-11 10
+    if [[ -f /etc/alternatives/cpp ]]; then update-alternatives --remove-all cpp; fi; update-alternatives --install /usr/bin/cpp cpp /usr/bin/cpp-11 10
+    if [[ -f /etc/alternatives/g++ ]]; then update-alternatives --remove-all g++; fi; update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-11 10
+    if [[ -f /etc/alternatives/gcc-ar ]]; then update-alternatives --remove-all gcc-ar; fi; update-alternatives --install /usr/bin/gcc-ar gcc-ar /usr/bin/gcc-ar-11 10
+    if [[ -f /etc/alternatives/gcov-tool ]]; then update-alternatives --remove-all gcov-tool; fi; update-alternatives --install /usr/bin/gcov-tool gcov-tool /usr/bin/gcov-tool-11 10
+    if [[ -f /etc/alternatives/gcc-ranlib ]]; then update-alternatives --remove-all gcc-ranlib; fi; update-alternatives --install /usr/bin/gcc-ranlib gcc-ranlib /usr/bin/gcc-ranlib-11 10
+    if [[ -f /etc/alternatives/gfortran ]]; then update-alternatives --remove-all gfortran; fi; update-alternatives --install /usr/bin/gfortran gfortran /usr/bin/gfortran-11 10
+
+    # Cleanup
+    rm -rf /var/tmp/* \
+        && rm -rf /tmp/* \
+        && rm -rf /var/cache/apt
+EOF
+
+## Install C buildkit
+
+RUN <<EOF
+    # C buildkit
+
+    # Install
+    apt-get install -y --no-install-recommends \
+        make ninja-build pkg-config ccache
+    curl --retry 3 --retry-connrefused -fL "https://github.com/Kitware/CMake/releases/download/v3.31.7/cmake-3.31.7-linux-$(uname -m).tar.gz" | tar -zx -C /usr --strip-components 1
+
+    # Install dependencies
+    apt-get install -y --no-install-recommends \
+        perl-openssl-defaults perl yasm \
+        zlib1g zlib1g-dev libbz2-dev libffi-dev libgdbm-dev libgdbm-compat-dev \
+        openssl libssl-dev libsqlite3-dev lcov libomp-dev \
+        libblas-dev liblapack-dev libopenblas-dev libblas3 liblapack3 libhdf5-dev \
+        libxml2 libxslt1-dev libgl1-mesa-glx libgmpxx4ldbl \
+        libncurses5-dev libreadline6-dev libsqlite3-dev \
+        liblzma-dev lzma lzma-dev tk-dev uuid-dev libmpdec-dev \
+        ffmpeg libjpeg-dev libpng-dev libtiff-dev libwebp-dev \
+        libnuma1 libnuma-dev libjemalloc-dev \
+        libgrpc-dev libgrpc++-dev libprotobuf-dev protobuf-compiler protobuf-compiler-grpc \
+        libnl-route-3-200 libnl-3-200 libnl-3-dev  libnl-route-3-dev \
+        libibverbs1 libibverbs-dev \
+        librdmacm1 librdmacm-dev \
+        libibumad3 libibumad-dev \
+        libtool \
+        ibverbs-utils ibverbs-providers libibverbs-dev \
+        openmpi-bin openmpi-common libopenmpi-dev
+
+    # Cleanup
+    rm -rf /var/tmp/* \
+        && rm -rf /tmp/* \
+        && rm -rf /var/cache/apt
+EOF
+
+## Upgrade Python if needed
+
+ARG PYTHON_VERSION
+
+ENV PYTHON_VERSION=${PYTHON_VERSION}
+
+RUN <<EOF
+    # Python
+
+    if (( $(echo "$(python3 --version | cut -d' ' -f2 | cut -d'.' -f1,2) == ${PYTHON_VERSION}" | bc -l) )); then
+        echo "Skipping Python upgrade for ${PYTHON_VERSION}..."
+        if [[ -z "$(ldconfig -v 2>/dev/null | grep libpython${PYTHON_VERSION})" ]]; then
+            PYTHON_LIB_PREFIX=$(python3 -c "import sys; print(sys.base_prefix);")
+            echo "${PYTHON_LIB_PREFIX}/lib" >> /etc/ld.so.conf.d/python3.conf
+            echo "${PYTHON_LIB_PREFIX}/lib64" >> /etc/ld.so.conf.d/python3.conf
+            ldconfig -v
+        fi
+        exit 0
+    fi
+
+    # Add deadsnakes PPA for Python versions
+    for i in 1 2 3; do
+        add-apt-repository -y ppa:deadsnakes/ppa && break || { echo "Attempt $i failed, retrying in 5s..."; sleep 5; }
+    done
+    apt-get update -y
+
+    # Install
+    apt-get install -y --no-install-recommends \
+        python${PYTHON_VERSION} \
+        python${PYTHON_VERSION}-dev \
+        python${PYTHON_VERSION}-venv \
+        python${PYTHON_VERSION}-lib2to3 \
+        python${PYTHON_VERSION}-gdbm \
+        python${PYTHON_VERSION}-tk
+    if (( $(echo "${PYTHON_VERSION} <= 3.11" | bc -l) )); then
+        apt-get install -y --no-install-recommends \
+            python${PYTHON_VERSION}-distutils
+    fi
+
+    # Update alternatives
+    if [[ -f /etc/alternatives/python3 ]]; then update-alternatives --remove-all python3; fi; update-alternatives --install /usr/bin/python3 python3 /usr/bin/python${PYTHON_VERSION} 1
+    if [[ -f /etc/alternatives/python ]]; then update-alternatives --remove-all python; fi; update-alternatives --install /usr/bin/python python /usr/bin/python${PYTHON_VERSION} 1
+    curl -sS "https://bootstrap.pypa.io/get-pip.py" | python${PYTHON_VERSION}
+    if [[ -f /etc/alternatives/2to3 ]]; then update-alternatives --remove-all 2to3; fi; update-alternatives --install /usr/bin/2to3 2to3 /usr/bin/2to3${PYTHON_VERSION} 1 || true
+    if [[ -f /etc/alternatives/pydoc3 ]]; then update-alternatives --remove-all pydoc3; fi; update-alternatives --install /usr/bin/pydoc3 pydoc3 /usr/bin/pydoc${PYTHON_VERSION} 1 || true
+    if [[ -f /etc/alternatives/idle3 ]]; then update-alternatives --remove-all idle3; fi; update-alternatives --install /usr/bin/idle3 idle3 /usr/bin/idle${PYTHON_VERSION} 1 || true
+    if [[ -f /etc/alternatives/python3-config ]]; then update-alternatives --remove-all python3-config; fi; update-alternatives --install /usr/bin/python3-config python3-config /usr/bin/python${PYTHON_VERSION}-config 1 || true
+
+    # Cleanup
+    rm -rf /var/tmp/* \
+        && rm -rf /tmp/* \
+        && rm -rf /var/cache/apt
+EOF
+
+## Install Python buildkit
+
+ENV PIP_NO_CACHE_DIR=1 \
+    PIP_DISABLE_PIP_VERSION_CHECK=1 \
+    PIP_ROOT_USER_ACTION=ignore \
+    PIPX_HOME=/root/.local/share/pipx \
+    PIPX_LOCAL_VENVS=/root/.local/share/pipx/venvs \
+    UV_NO_CACHE=1 \
+    UV_HTTP_TIMEOUT=500 \
+    UV_INDEX_STRATEGY="unsafe-best-match"
+
+RUN <<EOF
+    # Buildkit
+
+    cat <<EOT >/tmp/requirements.txt
+build
+cmake<4
+ninja<1.11
+setuptools>=77.0.3,<80.0.0
+setuptools-scm
+packaging<25
+wheel==0.45.1
+pybind11<3
+Cython
+psutil
+pipx<=1.8.0
+uv<=0.9.11
+EOT
+    pip install -r /tmp/requirements.txt
+
+    # Cleanup
+    rm -rf /var/tmp/* \
+        && rm -rf /tmp/*
+EOF
+
+## Declare Environment
+
+ARG GCU_VERSION
+ARG GCU_ARCHS
+
+ENV GCU_HOME="/usr/local/gcu" \
+    GCU_PATH="/usr/local/gcu" \
+    GCU_VERSION=${GCU_VERSION} \
+    GCU_ARCHS=${GCU_ARCHS} \
+    TOPS_RIDER_VERSION=${GCU_VERSION}
+
+# ============================================================
+# Stage: vllm
+# ============================================================
+
+FROM ${VLLM_BASE_IMAGE} AS vllm
+SHELL ["/bin/bash", "-eo", "pipefail", "-c"]
+
+ARG TARGETPLATFORM
+ARG TARGETOS
+ARG TARGETARCH
+
+ENV UV_SYSTEM_PYTHON=1 \
+    UV_PRERELEASE=allow \
+    UV_SKIP_WHEEL_FILENAME_CHECK=1
+
+## Install Torch
+
+## Nothing to do, as the Torch (torch_gcu) has installed in the vanilla image.
+
+## Install vLLM
+
+ARG VLLM_VERSION
+
+ENV VLLM_VERSION=${VLLM_VERSION}
+
+## Nothing to do, as the vLLM (vllm-gcu) has installed in the vanilla image.
+
+## Postprocess
+
+RUN <<EOF
+    # Postprocess
+
+    # Link if needed
+    if [[ ! -d ${GCU_HOME} ]] && [[ -d /usr/local/gcu-${GCU_VERSION} ]]; then
+        ln -vsf /usr/local/gcu-${GCU_VERSION} ${GCU_HOME}
+    fi
+
+    # Review
+    uv pip tree \
+        --package vllm
+EOF
+
+## Entrypoint
+
+ENV RAY_EXPERIMENTAL_NOSET_GCU_VISIBLE_DEVICES=1 \
+    VLLM_USE_V1=0 \
+    VLLM_ATTENTION_BACKEND="FLASH_ATTN" \
+    TORCHGCU_INDUCTOR_ENABLE=0 \
+    TOKENIZERS_PARALLELISM=false \
+    SAFETENSORS_FAST_GPU=1
+
+WORKDIR /
+ENTRYPOINT [ "tini", "--" ]

--- a/pack/gcu/Dockerfile.vllm
+++ b/pack/gcu/Dockerfile.vllm
@@ -1,0 +1,274 @@
+# syntax=docker/dockerfile:1
+
+# GPUStack Runner - Enflame GCU (燧原 S60) vLLM Pack
+#
+# This Dockerfile builds the vLLM service layer on top of the vanilla
+# image provided by Enflame.
+#
+# Argument usage:
+# - PYTHON_VERSION: Version of Python to use.
+# - GCU_VERSION: Version of Enflame TopsRider GCU runtime environment.
+# - GCU_VERSION_EXTRA: Extra version string.
+# - GCU_ARCHS: Arch variant (e.g., s60).
+# - VLLM_VERSION: Version of vLLM to use.
+# - VLLM_BASE_IMAGE: Base (vanilla) image for vLLM.
+
+ARG PYTHON_VERSION=3.10
+ARG GCU_VERSION=3.7.107
+ARG GCU_VERSION_EXTRA
+ARG GCU_ARCHS=s60
+ARG VLLM_VERSION=0.11.0
+ARG VLLM_BASE_IMAGE=gpustack/runner:gcu${GCU_VERSION}${GCU_VERSION_EXTRA}-python${PYTHON_VERSION}-vanilla
+
+# ============================================================
+# Stage: runtime
+# ============================================================
+
+FROM ${VLLM_BASE_IMAGE} AS runtime
+SHELL ["/bin/bash", "-eo", "pipefail", "-c"]
+
+ARG TARGETPLATFORM
+ARG TARGETOS
+ARG TARGETARCH
+
+## Install tools
+
+ENV DEBIAN_FRONTEND=noninteractive \
+    LANG='en_US.UTF-8' \
+    LANGUAGE='en_US:en' \
+    LC_ALL='en_US.UTF-8'
+
+RUN <<EOF
+    # Tools
+    apt-get update -y && apt-get install -y --no-install-recommends \
+        software-properties-common apt-transport-https \
+        ca-certificates gnupg2 lsb-release gnupg-agent \
+      && apt-get update -y \
+      && add-apt-repository -y ppa:ubuntu-toolchain-r/test \
+      && apt-get update -y
+
+    apt-get install -y --no-install-recommends \
+        ca-certificates build-essential binutils bash openssl \
+        curl wget aria2 \
+        git git-lfs \
+        unzip xz-utils \
+        tzdata locales \
+        iproute2 iputils-ping ifstat net-tools dnsutils pciutils ipmitool \
+        rdma-core rdmacm-utils infiniband-diags \
+        procps sysstat htop \
+        tini vim jq bc tree
+
+    localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
+
+    rm -f /etc/localtime \
+        && ln -sf /usr/share/zoneinfo/Asia/Shanghai /etc/localtime \
+        && echo "Asia/Shanghai" > /etc/timezone \
+        && dpkg-reconfigure --frontend noninteractive tzdata
+
+    rm -rf /var/tmp/* \
+        && rm -rf /tmp/* \
+        && rm -rf /var/cache/apt
+EOF
+
+## Upgrade GCC if needed
+
+RUN <<EOF
+    source /etc/os-release
+    if (( $(echo "${VERSION_ID} > 21.04" | bc -l) )); then
+        echo "Skipping GCC upgrade for ${VERSION_ID}..."
+        exit 0
+    fi
+
+    apt-get install -y --no-install-recommends \
+        gcc-11 g++-11 gfortran-11 gfortran
+
+    if [[ -f /etc/alternatives/gcov-dump ]]; then update-alternatives --remove-all gcov-dump; fi; update-alternatives --install /usr/bin/gcov-dump gcov-dump /usr/bin/gcov-dump-11 10
+    if [[ -f /etc/alternatives/lto-dump ]]; then update-alternatives --remove-all lto-dump; fi; update-alternatives --install /usr/bin/lto-dump lto-dump /usr/bin/lto-dump-11 10
+    if [[ -f /etc/alternatives/gcov ]]; then update-alternatives --remove-all gcov; fi; update-alternatives --install /usr/bin/gcov gcov /usr/bin/gcov-11 10
+    if [[ -f /etc/alternatives/gcc ]]; then update-alternatives --remove-all gcc; fi; update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-11 10
+    if [[ -f /etc/alternatives/gcc-nm ]]; then update-alternatives --remove-all gcc-nm; fi; update-alternatives --install /usr/bin/gcc-nm gcc-nm /usr/bin/gcc-nm-11 10
+    if [[ -f /etc/alternatives/cpp ]]; then update-alternatives --remove-all cpp; fi; update-alternatives --install /usr/bin/cpp cpp /usr/bin/cpp-11 10
+    if [[ -f /etc/alternatives/g++ ]]; then update-alternatives --remove-all g++; fi; update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-11 10
+    if [[ -f /etc/alternatives/gcc-ar ]]; then update-alternatives --remove-all gcc-ar; fi; update-alternatives --install /usr/bin/gcc-ar gcc-ar /usr/bin/gcc-ar-11 10
+    if [[ -f /etc/alternatives/gcov-tool ]]; then update-alternatives --remove-all gcov-tool; fi; update-alternatives --install /usr/bin/gcov-tool gcov-tool /usr/bin/gcov-tool-11 10
+    if [[ -f /etc/alternatives/gcc-ranlib ]]; then update-alternatives --remove-all gcc-ranlib; fi; update-alternatives --install /usr/bin/gcc-ranlib gcc-ranlib /usr/bin/gcc-ranlib-11 10
+    if [[ -f /etc/alternatives/gfortran ]]; then update-alternatives --remove-all gfortran; fi; update-alternatives --install /usr/bin/gfortran gfortran /usr/bin/gfortran-11 10
+
+    rm -rf /var/tmp/* \
+        && rm -rf /tmp/* \
+        && rm -rf /var/cache/apt
+EOF
+
+## Install C buildkit
+
+RUN <<EOF
+    apt-get install -y --no-install-recommends \
+        make ninja-build pkg-config ccache
+    curl --retry 3 --retry-connrefused -fL "https://github.com/Kitware/CMake/releases/download/v3.31.7/cmake-3.31.7-linux-$(uname -m).tar.gz" | tar -zx -C /usr --strip-components 1
+
+    apt-get install -y --no-install-recommends \
+        perl-openssl-defaults perl yasm \
+        zlib1g zlib1g-dev libbz2-dev libffi-dev libgdbm-dev libgdbm-compat-dev \
+        openssl libssl-dev libsqlite3-dev lcov libomp-dev \
+        libblas-dev liblapack-dev libopenblas-dev libblas3 liblapack3 libhdf5-dev \
+        libxml2 libxslt1-dev libgl1-mesa-glx libgmpxx4ldbl \
+        libncurses5-dev libreadline6-dev libsqlite3-dev \
+        liblzma-dev lzma lzma-dev tk-dev uuid-dev libmpdec-dev \
+        ffmpeg libjpeg-dev libpng-dev libtiff-dev libwebp-dev \
+        libnuma1 libnuma-dev libjemalloc-dev \
+        libgrpc-dev libgrpc++-dev libprotobuf-dev protobuf-compiler protobuf-compiler-grpc \
+        libnl-route-3-200 libnl-3-200 libnl-3-dev  libnl-route-3-dev \
+        libibverbs1 libibverbs-dev \
+        librdmacm1 librdmacm-dev \
+        libibumad3 libibumad-dev \
+        libtool \
+        ibverbs-utils ibverbs-providers libibverbs-dev \
+        openmpi-bin openmpi-common libopenmpi-dev
+
+    rm -rf /var/tmp/* \
+        && rm -rf /tmp/* \
+        && rm -rf /var/cache/apt
+EOF
+
+## Upgrade Python if needed
+
+ARG PYTHON_VERSION
+
+ENV PYTHON_VERSION=${PYTHON_VERSION}
+
+RUN <<EOF
+    if (( $(echo "$(python3 --version | cut -d' ' -f2 | cut -d'.' -f1,2) == ${PYTHON_VERSION}" | bc -l) )); then
+        echo "Skipping Python upgrade for ${PYTHON_VERSION}..."
+        if [[ -z "$(ldconfig -v 2>/dev/null | grep libpython${PYTHON_VERSION})" ]]; then
+            PYTHON_LIB_PREFIX=$(python3 -c "import sys; print(sys.base_prefix);")
+            echo "${PYTHON_LIB_PREFIX}/lib" >> /etc/ld.so.conf.d/python3.conf
+            echo "${PYTHON_LIB_PREFIX}/lib64" >> /etc/ld.so.conf.d/python3.conf
+            ldconfig -v
+        fi
+        exit 0
+    fi
+
+    for i in 1 2 3; do
+        add-apt-repository -y ppa:deadsnakes/ppa && break || { echo "Attempt $i failed, retrying in 5s..."; sleep 5; }
+    done
+    apt-get update -y
+
+    apt-get install -y --no-install-recommends \
+        python${PYTHON_VERSION} \
+        python${PYTHON_VERSION}-dev \
+        python${PYTHON_VERSION}-venv \
+        python${PYTHON_VERSION}-lib2to3 \
+        python${PYTHON_VERSION}-gdbm \
+        python${PYTHON_VERSION}-tk
+    if (( $(echo "${PYTHON_VERSION} <= 3.11" | bc -l) )); then
+        apt-get install -y --no-install-recommends \
+            python${PYTHON_VERSION}-distutils
+    fi
+
+    if [[ -f /etc/alternatives/python3 ]]; then update-alternatives --remove-all python3; fi; update-alternatives --install /usr/bin/python3 python3 /usr/bin/python${PYTHON_VERSION} 1
+    if [[ -f /etc/alternatives/python ]]; then update-alternatives --remove-all python; fi; update-alternatives --install /usr/bin/python python /usr/bin/python${PYTHON_VERSION} 1
+    curl -sS "https://bootstrap.pypa.io/get-pip.py" | python${PYTHON_VERSION}
+    if [[ -f /etc/alternatives/2to3 ]]; then update-alternatives --remove-all 2to3; fi; update-alternatives --install /usr/bin/2to3 2to3 /usr/bin/2to3${PYTHON_VERSION} 1 || true
+    if [[ -f /etc/alternatives/pydoc3 ]]; then update-alternatives --remove-all pydoc3; fi; update-alternatives --install /usr/bin/pydoc3 pydoc3 /usr/bin/pydoc${PYTHON_VERSION} 1 || true
+    if [[ -f /etc/alternatives/idle3 ]]; then update-alternatives --remove-all idle3; fi; update-alternatives --install /usr/bin/idle3 idle3 /usr/bin/idle${PYTHON_VERSION} 1 || true
+    if [[ -f /etc/alternatives/python3-config ]]; then update-alternatives --remove-all python3-config; fi; update-alternatives --install /usr/bin/python3-config python3-config /usr/bin/python${PYTHON_VERSION}-config 1 || true
+
+    rm -rf /var/tmp/* \
+        && rm -rf /tmp/* \
+        && rm -rf /var/cache/apt
+EOF
+
+## Install Python buildkit
+
+ENV PIP_NO_CACHE_DIR=1 \
+    PIP_DISABLE_PIP_VERSION_CHECK=1 \
+    PIP_ROOT_USER_ACTION=ignore \
+    PIPX_HOME=/root/.local/share/pipx \
+    PIPX_LOCAL_VENVS=/root/.local/share/pipx/venvs \
+    UV_NO_CACHE=1 \
+    UV_HTTP_TIMEOUT=500 \
+    UV_INDEX_STRATEGY="unsafe-best-match"
+
+RUN <<EOF
+    rm -rf /root/.pip/pip.conf /etc/pip.conf
+
+    cat <<EOT >/tmp/requirements.txt
+build
+cmake<4
+ninja<1.11
+setuptools>=77.0.3,<80.0.0
+setuptools-scm
+packaging<25
+wheel==0.45.1
+pybind11<3
+Cython
+psutil
+pipx<=1.8.0
+uv<=0.9.11
+EOT
+    pip install -r /tmp/requirements.txt
+
+    rm -rf /var/tmp/* \
+        && rm -rf /tmp/*
+EOF
+
+## Declare Environment
+
+ARG GCU_VERSION
+ARG GCU_ARCHS
+
+ENV GCU_HOME="/usr/local/gcu" \
+    GCU_PATH="/usr/local/gcu" \
+    GCU_VERSION=${GCU_VERSION} \
+    GCU_ARCHS=${GCU_ARCHS} \
+    TOPS_RIDER_VERSION=${GCU_VERSION}
+
+# ============================================================
+# Stage: vllm
+# ============================================================
+
+FROM runtime AS vllm
+SHELL ["/bin/bash", "-eo", "pipefail", "-c"]
+
+ARG TARGETPLATFORM
+ARG TARGETOS
+ARG TARGETARCH
+
+ENV UV_SYSTEM_PYTHON=1 \
+    UV_PRERELEASE=allow \
+    UV_SKIP_WHEEL_FILENAME_CHECK=1
+
+## Install vLLM
+
+ARG VLLM_VERSION
+
+ENV VLLM_VERSION=${VLLM_VERSION}
+
+## Nothing to do, as the vLLM (vllm-gcu) has installed in the vanilla image.
+
+## Postprocess
+
+RUN <<EOF
+    # Postprocess
+
+    # Link if needed
+    if [[ ! -d ${GCU_HOME} ]] && [[ -d /usr/local/gcu-${GCU_VERSION} ]]; then
+        ln -vsf /usr/local/gcu-${GCU_VERSION} ${GCU_HOME}
+    fi
+
+    # Review
+    uv pip tree \
+        --package vllm
+EOF
+
+## Entrypoint
+
+ENV RAY_EXPERIMENTAL_NOSET_GCU_VISIBLE_DEVICES=1 \
+    VLLM_USE_V1=0 \
+    VLLM_ATTENTION_BACKEND="FLASH_ATTN" \
+    TORCHGCU_INDUCTOR_ENABLE=0 \
+    TOKENIZERS_PARALLELISM=false \
+    SAFETENSORS_FAST_GPU=1
+
+WORKDIR /
+ENTRYPOINT [ "tini", "--" ]

--- a/pack/gcu/ISSUE_TEMPLATE.md
+++ b/pack/gcu/ISSUE_TEMPLATE.md
@@ -1,0 +1,85 @@
+# Enflame GCU (燧原 S60) Backend Support Request
+
+## Version Information
+
+| Component | Version | Notes |
+|-----------|---------|-------|
+| **vLLM-GCU** | 0.11.0 | Fork of vLLM 0.11.0 with GCU support |
+| **TopsRider (燧原加速框架)** | 3.7.107 | i3x 3.6+ series |
+| **Ubuntu** | 22.04 | LTS |
+| **Python** | 3.10 | (3.10 ~ 3.12 supported) |
+| **Hardware** | S60 GCU | Enflame GCU accelerator |
+| **PyTorch** | torch_gcu | Provided in vanilla image |
+
+## Vanilla Image
+
+```
+registry-egc.enflame-tech.com/artifacts/vllm_gcu:v0.11.0-TR3.7.107-ubuntu2204
+```
+
+This image already includes:
+- Enflame GCU driver and TopsRider SDK
+- torch_gcu (PyTorch for GCU)
+- vllm-gcu (vLLM with GCU backend)
+- triton_gcu
+
+## Supported Models
+
+vLLM-GCU supports a wide range of models including:
+- Qwen series (Qwen1.5/2/2.5/3, Qwen3-MoE, Qwen3-Next)
+- LLaMA series (LLaMA 2/3/3.1)
+- DeepSeek series (V3/R1/V3.2, Prover V2)
+- ChatGLM series (GLM3, GLM4)
+- Baichuan, Gemma, Mistral, Yi, InternLM, Mixtral, etc.
+- VLM models: Qwen2.5-VL, Step3-VL, GOT-OCR2, PaddleOCR-VL
+
+## Quantization Support
+
+- GPTQ (4-bit/8-bit)
+- AWQ (4-bit/8-bit)
+- W8A16
+- INT8 KV Cache
+
+## GitHub Repository
+
+https://github.com/EnflameTechnology/vllm-gcu
+
+## Dockerfile Location
+
+Dockerfiles have been added to `pack/gcu/`:
+- `pack/gcu/Dockerfile` - Combined runtime + vLLM stages
+- `pack/gcu/Dockerfile.vllm` - Per-service vLLM Dockerfile
+
+## copy.yml Workflow Parameters
+
+For the copy.yml workflow, the suggested parameters are:
+
+```
+src-registry: registry-egc.enflame-tech.com
+src-image: artifacts/vllm_gcu:v0.11.0-TR3.7.107-ubuntu2204
+src-username: [Enflame registry username]
+src-token: [Enflame registry token]
+dst-image-tag: gcu3.7.107-python3.10
+```
+
+This will produce the vanilla image:
+```
+gpustack/runner:gcu3.7.107-python3.10-vanilla
+```
+
+## Build Output Tags
+
+Following the naming convention of other backends:
+
+| Stage | Expected Tag |
+|-------|-------------|
+| Vanilla | `gpustack/runner:gcu3.7.107-python3.10-vanilla` |
+| Runtime | `gpustack/runner:gcu3.7.107-python3.10` |
+| vLLM | `gpustack/runner:gcu3.7.107-vllm0.11.0-python3.10` |
+
+## Notes
+
+1. SGLang support is not yet available for GCU. Only vLLM backend is supported.
+2. The vanilla image is based on Ubuntu 22.04.
+3. The TopsRider SDK path is typically `/usr/local/gcu` or similar.
+4. Environment variable for device visibility: `GCU_VISIBLE_DEVICES` (ray: `RAY_EXPERIMENTAL_NOSET_GCU_VISIBLE_DEVICES=1`).

--- a/pack/matrix.yaml
+++ b/pack/matrix.yaml
@@ -214,3 +214,20 @@ rules:
       - "MUSA_VERSION="
       - "MUSA_VERSION_EXTRA="
       - "VLLM_VERSION="
+
+  #
+  # Enflame GCU (燧原 S60)
+  #
+  ##
+  ## Use pack flow's arguments to override the default GCU version and version extra,
+  ## which are used in `pack/gcu/Dockerfile` to construct the image tags and build arguments.
+  ##
+  - backend: "gcu"
+    services:
+      - "vllm"
+    platforms:
+      - "linux/amd64"
+    args:
+      - "GCU_VERSION="
+      - "GCU_VERSION_EXTRA="
+      - "VLLM_VERSION="


### PR DESCRIPTION
# feat(pack): add Enflame GCU (燧原 S60) backend support

## Summary

Add Dockerfile support for Enflame GCU (燧原 S60) to the GPUStack runner pack system.

## Changes

- **New directory**: `pack/gcu/`
  - `Dockerfile` — Combined build with vanilla → runtime → vllm stages
  - `Dockerfile.vllm` — Per-service vLLM Dockerfile (runtime + vllm targets)
- **Modified**: `pack/matrix.yaml` — Added `gcu` backend rule

## Version Information

| Component | Version |
|-----------|---------|
| TopsRider (燧原加速框架) | 3.7.107 (i3x 3.6+) |
| vLLM-GCU | 0.11.0 |
| Python | 3.10 |
| OS | Ubuntu 22.04 |
| Hardware | S60 GCU |

## Vanilla Image

```
registry-egc.enflame-tech.com/artifacts/vllm_gcu:v0.11.0-TR3.7.107-ubuntu2204
```

This image is provided by Enflame and includes:
- Enflame GCU driver and TopsRider SDK
- `torch_gcu` (PyTorch for GCU)
- `vllm-gcu` (vLLM with GCU backend)
- `triton_gcu`

## Expected Image Tags

After the copy.yml workflow runs and the Dockerfiles are built:

| Stage | Tag |
|-------|-----|
| Vanilla | `gpustack/runner:gcu3.7.107-python3.10-vanilla` |
| Runtime | `gpustack/runner:gcu3.7.107-python3.10` |
| vLLM | `gpustack/runner:gcu3.7.107-vllm0.11.0-python3.10` |

## copy.yml Parameters

For the GitHub Action `copy.yml`, the suggested inputs:

```
src-registry: registry-egc.enflame-tech.com
src-image: artifacts/vllm_gcu:v0.11.0-TR3.7.107-ubuntu2204
dst-image-tag: gcu3.7.107-python3.10
```

## Build & Test

To build the runtime image locally:
```bash
docker build --progress=plain --platform=linux/amd64 \
  --file=pack/gcu/Dockerfile \
  --tag=gpustack/runner:gcu3.7.107-python3.10 \
  --target=runtime \
  pack/gcu
```

To build the vLLM image:
```bash
docker build --progress=plain --platform=linux/amd64 \
  --file=pack/gcu/Dockerfile \
  --tag=gpustack/runner:gcu3.7.107-vllm0.11.0-python3.10 \
  --target=vllm \
  pack/gcu
```

## Notes

- Only vLLM backend is supported (SGLang support not yet available for GCU)
- The vanilla image is Ubuntu 22.04 based
- Device visibility env var: `GCU_VISIBLE_DEVICES`
- Uses `RAY_EXPERIMENTAL_NOSET_GCU_VISIBLE_DEVICES=1` in entrypoint

## Related

- vLLM-GCU upstream: https://github.com/EnflameTechnology/vllm-gcu
- Enflame official: https://www.enflame-tech.com/
