### PR TITLE
fix(dtk): remove CUDA-only NIXL EP and pin NumPy 1.x

### DIFF
--- a/pack/dtk/Dockerfile.vllm
+++ b/pack/dtk/Dockerfile.vllm
@@ -330,16 +330,15 @@ EOF
 # require libcuda.so.1 and cannot run on Hygon DCU systems.
 #
 # vLLM detects NIXL EP through importlib.util.find_spec("nixl_ep"). Remove
-# the packages entirely, rather than leaving an ImportError stub, so vLLM
-# selects its non-NIXL path.
+# the distributions entirely, rather than leaving an ImportError stub, so
+# vLLM selects its non-NIXL path. Use uv to resolve the active Python
+# environment and package paths instead of relying on a fixed site-packages
+# location.
 RUN <<EOF
-    rm -rf \
-        /usr/local/lib/python${PYTHON_VERSION}/dist-packages/nixl_ep \
-        /usr/local/lib/python${PYTHON_VERSION}/dist-packages/nixl_ep_cu12 \
-        /usr/local/lib/python${PYTHON_VERSION}/dist-packages/nixl_ep_cu13 \
-        /usr/local/lib/python${PYTHON_VERSION}/dist-packages/nixl_ep-*.dist-info \
-        /usr/local/lib/python${PYTHON_VERSION}/dist-packages/nixl_ep_cu12-*.dist-info \
-        /usr/local/lib/python${PYTHON_VERSION}/dist-packages/nixl_ep_cu13-*.dist-info
+    # The NIXL EP modules are owned by the nixl, nixl-cu12, and nixl-cu13
+    # distributions in the DTK base image. Do not fail if a future base image
+    # no longer includes one of them; the import check below remains required.
+    uv pip uninstall nixl nixl-cu12 nixl-cu13 || true
 
     python - <<'PYEOF'
 import importlib.util

--- a/pack/dtk/Dockerfile.vllm
+++ b/pack/dtk/Dockerfile.vllm
@@ -323,6 +323,33 @@ RUN <<EOF
         && rm -rf /tmp/*
 EOF
 
+## Remove CUDA-only NIXL EP packages
+
+# The prebuilt DTK vLLM base image can inherit NIXL Expert Parallel packages
+# from its Python environment. NIXL EP provides NVIDIA CUDA backends which
+# require libcuda.so.1 and cannot run on Hygon DCU systems.
+#
+# vLLM detects NIXL EP through importlib.util.find_spec("nixl_ep"). Remove
+# the packages entirely, rather than leaving an ImportError stub, so vLLM
+# selects its non-NIXL path.
+RUN <<EOF
+    rm -rf \
+        /usr/local/lib/python${PYTHON_VERSION}/dist-packages/nixl_ep \
+        /usr/local/lib/python${PYTHON_VERSION}/dist-packages/nixl_ep_cu12 \
+        /usr/local/lib/python${PYTHON_VERSION}/dist-packages/nixl_ep_cu13 \
+        /usr/local/lib/python${PYTHON_VERSION}/dist-packages/nixl_ep-*.dist-info \
+        /usr/local/lib/python${PYTHON_VERSION}/dist-packages/nixl_ep_cu12-*.dist-info \
+        /usr/local/lib/python${PYTHON_VERSION}/dist-packages/nixl_ep_cu13-*.dist-info
+
+    python - <<'PYEOF'
+import importlib.util
+
+for module_name in ("nixl_ep", "nixl_ep_cu12", "nixl_ep_cu13"):
+    assert importlib.util.find_spec(module_name) is None, \
+        f"{module_name} is still discoverable after DTK image cleanup"
+PYEOF
+EOF
+
 ## Postprocess
 
 RUN <<EOF

--- a/pack/dtk/Dockerfile.vllm
+++ b/pack/dtk/Dockerfile.vllm
@@ -323,6 +323,25 @@ RUN <<EOF
         && rm -rf /tmp/*
 EOF
 
+## Restore NumPy 1.x ABI compatibility
+
+# The DTK base image currently ships a Torch build compiled against the NumPy
+# 1.x ABI. NumPy 2.x cannot initialize in that Torch build, which causes
+# distributed initialization to fail when it calls Tensor.numpy().
+#
+# Install without dependencies to avoid changing the prebuilt DTK Python
+# environment beyond the NumPy compatibility pin.
+RUN <<EOF
+    uv pip install --no-deps "numpy==1.26.4"
+
+    python - <<'PYEOF'
+import numpy
+
+assert numpy.__version__ == "1.26.4", \
+    f"expected numpy 1.26.4, got {numpy.__version__}"
+PYEOF
+EOF
+
 ## Remove CUDA-only NIXL EP packages
 
 # The prebuilt DTK vLLM base image can inherit NIXL Expert Parallel packages


### PR DESCRIPTION
## Summary

Fix two startup blockers in DTK vLLM images inherited from the prebuilt DTK Python environment:

1. CUDA-only NIXL Expert Parallel packages are discoverable on Hygon DCU and cause vLLM to load a native extension that requires NVIDIA `libcuda.so.1`.
2. The DTK Torch build was compiled against the NumPy 1.x ABI, but the image ships NumPy 2.x. Torch then cannot initialize NumPy, which breaks distributed initialization when it calls `Tensor.numpy()`.

## NIXL EP failure

vLLM 0.18 detects the optional NIXL dependency with:

```python
importlib.util.find_spec("nixl_ep") is not None
```

When the packages are installed, vLLM follows this import path:

```text
all2all_utils.py -> has_nixl_ep() -> nixl_ep_prepare_finalize.py
  -> nixl_ep -> nixl_ep_cu13 -> nixl_ep_cpp.so -> libcuda.so.1
```

On Hygon DCU this fails with:

```text
ImportError: libcuda.so.1: cannot open shared object file: No such file or directory
ImportError: No usable nixl_ep CUDA backend found
```

The DTK base image exposes the relevant Python distributions as `nixl`, `nixl-cu12`, and `nixl-cu13`, while their import modules are named `nixl_ep*`.

## NumPy ABI failure

The image's NumPy 2.x installation produces:

```text
A module that was compiled using NumPy 1.x cannot be run in NumPy 2.2.6
UserWarning: Failed to initialize NumPy: _ARRAY_API not found
```

During tensor-parallel initialization, the resulting failure is:

```text
RuntimeError: Numpy is not available
```

with the relevant path:

```text
torch.distributed.distributed_c10d.py
  -> tensor.numpy().tobytes()
```

## Change

Only `pack/dtk/Dockerfile.vllm` is changed:

- Pin `numpy==1.26.4` using `uv pip install --no-deps` and assert that version during image build.
- Remove the `nixl`, `nixl-cu12`, and `nixl-cu13` distributions using `uv pip uninstall`, allowing uv to resolve the actual active Python environment and package locations.
- Assert at build time that `importlib.util.find_spec()` cannot discover `nixl_ep`, `nixl_ep_cu12`, or `nixl_ep_cu13`.
- Leave vLLM source files unchanged. Its existing `has_nixl_ep()` guard then selects the non-NIXL path.

## Validation

Validated on:

- Hygon K500SM_AI
- DTK 26.04
- GPUStack 2.2.3
- `quay.io/gpustack/runner:dtk26.04-vllm0.18.1`
- vLLM 0.18.1
- `Qwen/Qwen3.6-27B`, tensor parallel size 4

After applying both fixes, the model completed distributed initialization and served a successful request:

```text
POST /v1/chat/completions HTTP/1.1" 200 OK
```

Local checks:

- `pre-commit run --files pack/dtk/Dockerfile.vllm`
- `git diff --check`