### PR TITLE
chore: capitalize GitHub workflow names

### DIFF
--- a/.github/workflows/copy.yml
+++ b/.github/workflows/copy.yml
@@ -4,7 +4,7 @@
 # The destination image is optionally suffixed with "-vanilla" (enabled by default).
 # The workflow is triggered manually via the GitHub Actions UI.
 
-name: COPY
+name: Copy
 
 permissions:
   actions: read

--- a/.github/workflows/discard.yml
+++ b/.github/workflows/discard.yml
@@ -1,7 +1,7 @@
 # This workflow is used to discard runners by creating a pull request.
 # It can be triggered manually via the GitHub Actions UI.
 
-name: DISCARD
+name: Discard
 
 permissions:
   actions: write

--- a/.github/workflows/pack.yml
+++ b/.github/workflows/pack.yml
@@ -4,7 +4,7 @@
 # It also supports dry runs to check the matrix and Dockerfile without building images.
 # The workflow is triggered manually via the GitHub Actions UI.
 
-name: PACK
+name: Pack
 
 permissions:
   actions: write

--- a/.github/workflows/prune.yml
+++ b/.github/workflows/prune.yml
@@ -1,7 +1,7 @@
 # This workflow is used to prune runners by creating a pull request.
 # It can be triggered manually via the GitHub Actions UI.
 
-name: PRUNE
+name: Prune
 
 permissions:
   actions: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,7 @@
 # This workflow runs for releasing the package to PyPI.
 # It triggers on workflow dispatch or when a tag matching 'v*.*.*' is pushed.
 
-name: RELEASE
+name: Release
 
 permissions:
   actions: read

--- a/.github/workflows/squash.yml
+++ b/.github/workflows/squash.yml
@@ -2,7 +2,7 @@
 # It supports squashing images for multiple OS/ARCH and creating manifest list.
 # The workflow is triggered manually via GitHub Actions UI.
 
-name: SQUASH
+name: Squash
 
 permissions:
   actions: read


### PR DESCRIPTION
## Summary

Rename workflow display names from all-uppercase to first-letter capitalized (`CI` kept as-is):

- `COPY` → `Copy`
- `DISCARD` → `Discard`
- `PACK` → `Pack`
- `PRUNE` → `Prune`
- `RELEASE` → `Release`
- `SQUASH` → `Squash`