### PR TITLE
feat(dtk): post-operation to pin numpy and remove nixl ep for vllm 0.18.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@
 .DS_Store
 *.swp
 
+# Local agent tooling
+.claude/
+
 # C extensions
 *.so
 

--- a/pack/.post_operation/20260901_dtk_pin_numpy_remove_nixl_ep/dtk/Dockerfile
+++ b/pack/.post_operation/20260901_dtk_pin_numpy_remove_nixl_ep/dtk/Dockerfile
@@ -1,0 +1,67 @@
+ARG DTK_VERSION=26.04
+ARG VLLM_VERSION=0.18.1
+
+FROM gpustack/runner:dtk${DTK_VERSION}-vllm${VLLM_VERSION} AS vllm
+SHELL ["/bin/bash", "-eo", "pipefail", "-c"]
+
+ARG TARGETPLATFORM
+ARG TARGETOS
+ARG TARGETARCH
+
+## Restore NumPy 1.x ABI compatibility
+
+# The DTK base image currently ships a Torch build compiled against the NumPy
+# 1.x ABI. NumPy 2.x cannot initialize in that Torch build, which causes
+# distributed initialization to fail when it calls Tensor.numpy().
+#
+# Install without dependencies to avoid changing the prebuilt DTK Python
+# environment beyond the NumPy compatibility pin.
+RUN <<EOF
+    uv pip install --no-deps "numpy==1.26.4"
+
+    python - <<'PYEOF'
+import numpy
+
+assert numpy.__version__ == "1.26.4", \
+    f"expected numpy 1.26.4, got {numpy.__version__}"
+PYEOF
+EOF
+
+## Remove CUDA-only NIXL EP packages
+
+# The prebuilt DTK vLLM base image can inherit NIXL Expert Parallel packages
+# from its Python environment. NIXL EP provides NVIDIA CUDA backends which
+# require libcuda.so.1 and cannot run on Hygon DCU systems.
+#
+# vLLM detects NIXL EP through importlib.util.find_spec("nixl_ep"). Remove
+# the distributions entirely, rather than leaving an ImportError stub, so
+# vLLM selects its non-NIXL path. Use uv to resolve the active Python
+# environment and package paths instead of relying on a fixed site-packages
+# location.
+RUN <<EOF
+    # The NIXL EP modules are owned by the nixl, nixl-cu12, and nixl-cu13
+    # distributions in the DTK base image. Do not fail if a future base image
+    # no longer includes one of them; the import check below remains required.
+    uv pip uninstall nixl nixl-cu12 nixl-cu13 || true
+
+    python - <<'PYEOF'
+import importlib.util
+
+for module_name in ("nixl_ep", "nixl_ep_cu12", "nixl_ep_cu13"):
+    assert importlib.util.find_spec(module_name) is None, \
+        f"{module_name} is still discoverable after DTK image cleanup"
+PYEOF
+EOF
+
+RUN <<EOF
+    # Review
+    uv pip tree \
+        --package numpy \
+        --package torch \
+        --package vllm
+EOF
+
+## Entrypoint
+
+WORKDIR /
+ENTRYPOINT [ "tini", "--" ]

--- a/pack/.post_operation/20260901_dtk_pin_numpy_remove_nixl_ep/matrix.yaml
+++ b/pack/.post_operation/20260901_dtk_pin_numpy_remove_nixl_ep/matrix.yaml
@@ -1,0 +1,16 @@
+rules:
+
+  #
+  # Hygon DTK
+  #
+
+  ## Packed Hygon DTK 26.04.
+  ##
+  - backend: "dtk"
+    services:
+      - "vllm"
+    platforms:
+      - "linux/amd64"
+    args:
+      - "DTK_VERSION=26.04"
+      - "VLLM_VERSION=0.18.1"

--- a/pack/.post_operation/README.md
+++ b/pack/.post_operation/README.md
@@ -44,3 +44,4 @@ We leverage the matrix expansion feature of GPUStack Runner to achieve this, and
 - [ ] 2026-02-14: Patch SGLang 0.5.8.post1 of CANN/CUDA/ROCm released images to reduce Z-Image loading memory occupation.
 - [x] 2026-02-28: Reinstall `vllm-omni` packages for vLLM 0.16.0 of CUDA released images.
 - [x] 2026-03-03: Fix malformed ARM64 image for vLLM 0.15.1 of CUDA released images.
+- [ ] 2026-09-01: Pin `numpy` to 1.26.4 and remove CUDA-only NIXL EP packages for vLLM 0.18.1 of DTK 26.04 released images.


### PR DESCRIPTION
## Summary

Add post-operation `20260901_dtk_pin_numpy_remove_nixl_ep` to patch the released `gpustack/runner:dtk26.04-vllm0.18.1` image in place, backporting #265 (commit range bc1428ff..372b4116) to the already-published tag:

- Pin `numpy==1.26.4` (`uv pip install --no-deps`) with a build-time version assertion — the prebuilt DTK Torch is compiled against the NumPy 1.x ABI, and NumPy 2.x breaks distributed init at `Tensor.numpy()`.
- Remove CUDA-only NIXL EP distributions (`uv pip uninstall nixl nixl-cu12 nixl-cu13 || true`) with a build-time assertion that `nixl_ep*` modules are no longer discoverable — they make vLLM load an extension requiring NVIDIA `libcuda.so.1`, which fails on Hygon DCU.

Package layout follows existing post-operation conventions (`matrix.yaml` + `dtk/Dockerfile`), and the operation is logged in `pack/.post_operation/README.md`.

Also ignores the local `.claude/` tooling directory.

## Validation

- `pre-commit run` on all changed files — green.
- Local matrix expansion smoke — exactly one job: `dtk26.04-vllm0.18.1-linux-amd64`.
- Pack workflow dry-run on this branch — green: https://github.com/gpustack/runner/actions/runs/33489120235

## Rollout (after merge)

1. Pack workflow: `post_operation=20260901_dtk_pin_numpy_remove_nixl_ep`, `backend=dtk`, `target=vllm`, `tag=dtk26.04-vllm0.18.1`, `dry_run=false`, `for_release=false` → pushes `-dev` tag.
2. Runtime validation on Hygon DCU with the `-dev` tag.
3. Re-run with `for_release=true` to overwrite the released tag, then check off the README entry.