### PR TITLE
docs(dtk): mark vllm 0.18.1 image as updated in place

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ The following table lists the supported accelerated backends and their correspon
 
 | DTK Version <br/> (Variant) | vLLM                                 | SGLang     |
 |-----------------------------|--------------------------------------|------------|
-| 26.04                       | `0.18.1`                             | `0.5.10`(rc) |
+| 26.04                       | **`0.18.1`**                         | `0.5.10`(rc) |
 | 25.04                       | `0.18.1`, `0.11.0`, `0.9.2`, `0.8.5` |            |
 
 ### T-Head HGGC

--- a/pack/.post_operation/README.md
+++ b/pack/.post_operation/README.md
@@ -44,4 +44,4 @@ We leverage the matrix expansion feature of GPUStack Runner to achieve this, and
 - [ ] 2026-02-14: Patch SGLang 0.5.8.post1 of CANN/CUDA/ROCm released images to reduce Z-Image loading memory occupation.
 - [x] 2026-02-28: Reinstall `vllm-omni` packages for vLLM 0.16.0 of CUDA released images.
 - [x] 2026-03-03: Fix malformed ARM64 image for vLLM 0.15.1 of CUDA released images.
-- [ ] 2026-09-01: Pin `numpy` to 1.26.4 and remove CUDA-only NIXL EP packages for vLLM 0.18.1 of DTK 26.04 released images.
+- [x] 2026-09-01: Pin `numpy` to 1.26.4 and remove CUDA-only NIXL EP packages for vLLM 0.18.1 of DTK 26.04 released images.


### PR DESCRIPTION
## Summary

The `gpustack/runner:dtk26.04-vllm0.18.1` released image was updated in place via post-operation `20260901_dtk_pin_numpy_remove_nixl_ep` (NumPy 1.26.4 pin + CUDA-only NIXL EP removal, backporting #265).

- Bold the vLLM **0.18.1** entry for DTK 26.04 in the README support matrix.
- Check off the 2026-09-01 entry in `pack/.post_operation/README.md`.

Release builds: dev tag https://github.com/gpustack/runner/actions/runs/33489561748, release tag https://github.com/gpustack/runner/actions/runs/33490654584.